### PR TITLE
fix: read message IDs from database instead of JSON storage in loadMessages

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -44,7 +44,8 @@ import { LLM } from "./llm"
 import { iife } from "@/util/iife"
 import { Shell } from "@/shell/shell"
 import { Truncate } from "@/tool/truncation"
-import { Storage } from "../storage/storage"
+import { Database, desc, eq } from "../storage/db"
+import { MessageTable } from "./session.sql"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -279,7 +280,16 @@ export namespace SessionPrompt {
         }
       | undefined,
   ) {
-    const order = (await Storage.list(["message", sessionID])).map((item) => item[2] as string).reverse()
+    const order = Database.use((db) =>
+      db
+        .select({ id: MessageTable.id })
+        .from(MessageTable)
+        .where(eq(MessageTable.session_id, sessionID))
+        .orderBy(desc(MessageTable.time_created))
+        .all(),
+    ).map((row) => row.id)
+    // order is newest-first from DB; reverse so oldest is first
+    order.reverse()
     if (!cached) {
       const messages = await Promise.all(order.map((id) => MessageV2.get({ sessionID, messageID: id })))
       return {


### PR DESCRIPTION
## Summary

- Fixed `loadMessages` in `packages/opencode/src/session/prompt.ts` to query message IDs from the SQLite database (`MessageTable`) instead of JSON file storage (`Storage.list`)
- This fixes the "No user message found in stream" exception thrown when submitting any message

## Root Cause

The `loadMessages` function (introduced in this branch for caching optimization) used `Storage.list(["message", sessionID])` to discover message IDs from JSON file storage. However, `Session.updateMessage` only writes to the SQLite database — no JSON files are created for messages. This caused `Storage.list` to always return an empty array, resulting in zero messages loaded, and the error at line 385:

```
throw new Error("No user message found in stream. This should never happen.")
```

## Fix

Replaced `Storage.list` with a Drizzle DB query against `MessageTable`:

```ts
const order = Database.use((db) =>
  db.select({ id: MessageTable.id })
    .from(MessageTable)
    .where(eq(MessageTable.session_id, sessionID))
    .orderBy(desc(MessageTable.time_created))
    .all()
).map((row) => row.id)
order.reverse()
```

This preserves the caching optimization (only fetch new messages on subsequent loop iterations) while correctly reading from the database where messages actually live.

## Verification

- [x] Build passes (`bun run script/build.ts`)
- [x] Typecheck passes (12/12 packages)
- [x] Tests pass (963 pass, 5 skip, 5 pre-existing timeouts unrelated to this change)
- [x] Ordering semantics verified: oldest-first, matching upstream `MessageV2.stream` + `filterCompacted` behavior