### PR TITLE
chore: add temp and generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ target
 opencode-dev
 logs/
 *.bun-build
+.reflection/
+.tts/
+.tts-debug.log
+session-*.md
+packages/sdk/js/openapi.json


### PR DESCRIPTION
## Summary

- Adds `.reflection/`, `.tts/`, `.tts-debug.log`, `session-*.md`, and `packages/sdk/js/openapi.json` to `.gitignore`
- These are local dev artifacts (TTS debug output, session exports, reflection cache, generated SDK spec) that should not be tracked