### PR TITLE
fix: load messages from db when storage is missing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,3 +122,4 @@ const table = sqliteTable("session", {
 
 - If you make a mistake and learn something project-specific from it, append the lesson to this file under the relevant section. Keep it short and technical.
 - Promptfoo `azure:responses` evaluations fail with `2025-04-01-preview`; use `apiVersion=preview` instead.
+- Headless `opencode serve` persists messages in SQLite only; `SessionPrompt.loadMessages` must fall back to `MessageV2.stream` when storage JSON files are absent.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -282,6 +282,20 @@ export namespace SessionPrompt {
       | undefined,
   ) {
     const order = (await Storage.list(["message", sessionID])).map((item) => item[2] as string).reverse()
+    if (order.length === 0) {
+      const messages: MessageV2.WithParts[] = []
+      for await (const msg of MessageV2.stream(sessionID)) {
+        messages.push(msg)
+      }
+      messages.reverse()
+      return {
+        messages,
+        cache: {
+          order: messages.map((msg) => msg.info.id),
+          map: new Map(messages.map((msg) => [msg.info.id, msg])),
+        },
+      }
+    }
     if (!cached) {
       const messages = await Promise.all(order.map((id) => MessageV2.get({ sessionID, messageID: id })))
       return {


### PR DESCRIPTION
## Summary
- fall back to SQLite message stream when storage JSON files are absent (headless serve)
- prevents prompt loop from failing with "No user message found" during evals
- add note to AGENTS.md about storage/SQLite behavior

## Testing
- bun run --cwd packages/opencode script/build.ts
- PROMPTFOO_CACHE_ENABLED=false bun run --cwd packages/opencode eval:hello