### PR TITLE
fix: bound per-directory instance cache to prevent serve memory blowups

### DIFF
--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -19,7 +19,7 @@ const seen = new Map<string, number>()
 const max = (() => {
   const val = Number(process.env.OPENCODE_INSTANCE_MAX)
   if (Number.isFinite(val)) return val
-  return 4
+  return 2
 })()
 
 const idle = (() => {


### PR DESCRIPTION
## Summary
- add bounded Instance cache with idle eviction in packages/opencode/src/project/instance.ts
- track in-flight refs per directory and only evict idle entries
- keep hard disposal path for reload/shutdown and dedupe concurrent sweeps
- add env knobs:
  - OPENCODE_INSTANCE_MAX (default 4, <=0 disables size bound)
  - OPENCODE_INSTANCE_IDLE_MS (default 600000)

## Why
opencode serve can accumulate many per-directory instances under multi-project traffic. Each instance bootstraps heavy subsystems (including MCP clients/processes). Without eviction this grows process-tree RSS quickly and can exceed 5GB.

## Validation
- bun run typecheck (packages/opencode) passed
- default-port guard run with patched local build did not breach 5GB in 40-90s runs, peak stayed below threshold

## Related
- https://github.com/anomalyco/opencode/issues/12687