### PR TITLE
fix(session): mark recovered assistant turns as aborted

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -935,7 +935,7 @@ export namespace Session {
     // Complete orphaned assistant messages that never got time.completed
     const msgs = Database.use((db) =>
       db
-        .select({ id: MessageTable.id, updated: MessageTable.time_updated })
+        .select({ id: MessageTable.id, data: MessageTable.data, updated: MessageTable.time_updated })
         .from(MessageTable)
         .where(
           and(
@@ -948,10 +948,25 @@ export namespace Session {
     if (msgs.length > 0) {
       log.info("recovering orphaned assistant messages", { count: msgs.length })
       for (const msg of msgs) {
+        const data = msg.data as MessageV2.Assistant
+        if (data?.role !== "assistant" || !data?.time) continue
+        const patched: MessageV2.Assistant = {
+          ...data,
+          role: "assistant",
+          time: {
+            ...data.time,
+            completed: msg.updated,
+          },
+          error:
+            data.error ??
+            new MessageV2.AbortedError({
+              message: "Server restarted while the response was in progress",
+            }).toObject(),
+        }
         Database.use((db) =>
           db
             .update(MessageTable)
-            .set({ data: sql`json_set(${MessageTable.data}, '$.time.completed', ${msg.updated})` })
+            .set({ data: patched })
             .where(eq(MessageTable.id, msg.id))
             .run(),
         )

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -140,3 +140,77 @@ describe("step-finish token propagation via Bus event", () => {
     { timeout: 30000 },
   )
 })
+
+describe("session recovery", () => {
+  test("marks orphaned assistant messages as aborted on restart recovery", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+        const user = await Session.updateMessage({
+          id: MessageID.ascending(),
+          sessionID: session.id,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "user",
+          model: { providerID: "test", modelID: "test" },
+          tools: {},
+          mode: "",
+        } as unknown as MessageV2.Info)
+
+        const assistant = await Session.updateMessage({
+          id: MessageID.ascending(),
+          sessionID: session.id,
+          role: "assistant",
+          time: { created: Date.now() },
+          parentID: user.id,
+          modelID: "test",
+          providerID: "test",
+          mode: "build",
+          agent: "build",
+          path: { cwd: projectRoot, root: projectRoot },
+          cost: 0,
+          tokens: {
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+        } as unknown as MessageV2.Info)
+
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: assistant.id,
+          sessionID: session.id,
+          type: "tool",
+          tool: "bash",
+          callID: "call-recover",
+          state: {
+            status: "running",
+            input: { command: "echo stuck" },
+            time: { start: Date.now() },
+          },
+        } satisfies MessageV2.ToolPart)
+
+        Session.recover()
+
+        const recovered = await MessageV2.get({
+          sessionID: session.id,
+          messageID: assistant.id,
+        })
+        const tool = recovered.parts.find((part): part is MessageV2.ToolPart => part.type === "tool")
+
+        expect(recovered.info.role).toBe("assistant")
+        if (recovered.info.role !== "assistant") throw new Error("expected recovered assistant message")
+        expect(recovered.info.time.completed).toBeDefined()
+        expect(recovered.info.error?.name).toBe("MessageAbortedError")
+        expect(recovered.info.error?.data.message).toContain("Server restarted")
+        expect(tool?.state.status).toBe("error")
+        if (!tool || tool.state.status !== "error") throw new Error("expected recovered tool error")
+        expect(tool.state.error).toBe("Tool execution aborted: server restarted")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
When the server restarts during an in-flight session turn, `Session.recover()` already converts running tool parts into `server restarted` errors and force-completes unfinished assistant messages. The missing piece was that those assistant messages were still stored as successful completions with `error: null`.

This patch marks recovered orphaned assistant messages as `MessageAbortedError` so the UI renders the turn as interrupted instead of looking like a silent dead-end or stuck session.

Closes #24

## Changes
- load assistant message data during startup recovery
- mark recovered orphaned assistant messages as `MessageAbortedError` if they do not already carry an error
- preserve the recovered `time.completed` behavior
- add a regression test covering orphaned assistant + running tool recovery

## Testing
- `bun test test/session/session.test.ts`
- `bun typecheck`
- browser-visible isolated E2E with a seeded orphaned session on a patched local server: page renders `Interrupted` plus the `server restarted` tool error and no stale active session state
