### PR TITLE
fix(session): retry only empty aborted turns

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -364,7 +364,10 @@ export namespace SessionProcessor {
                 error,
               })
             } else {
-              const retry = SessionRetry.retryable(error, input.abort)
+              const retry = SessionRetry.retryable(error, {
+                abort: input.abort,
+                empty: (await MessageV2.parts(input.assistantMessage.id)).length === 0,
+              })
               if (retry !== undefined) {
                 attempt++
                 const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -58,11 +58,15 @@ export namespace SessionRetry {
     return Math.min(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_NO_HEADERS)
   }
 
-  export function retryable(error: ReturnType<NamedError["toObject"]>, abort?: AbortSignal) {
+  export function retryable(
+    error: ReturnType<NamedError["toObject"]>,
+    opts?: { abort?: AbortSignal; empty?: boolean },
+  ) {
     // context overflow errors should not be retried
     if (MessageV2.ContextOverflowError.isInstance(error)) return undefined
     if (MessageV2.AbortedError.isInstance(error)) {
-      if (abort?.aborted) return undefined
+      if (opts?.abort?.aborted) return undefined
+      if (opts?.empty === false) return undefined
       return error.data.message
     }
     if (MessageV2.APIError.isInstance(error)) {

--- a/packages/opencode/test/session/processor.test.ts
+++ b/packages/opencode/test/session/processor.test.ts
@@ -74,6 +74,15 @@ function output(values: unknown[]) {
   } as unknown as Stream
 }
 
+function fail(values: unknown[], error: unknown) {
+  return {
+    fullStream: (async function* () {
+      for (const value of values) yield value
+      throw error
+    })(),
+  } as unknown as Stream
+}
+
 async function run(
   fn: (input: {
     agent: Agent.Info
@@ -174,6 +183,54 @@ describe("session.processor", () => {
         expect(result).toBe("stop")
         expect(stream).toHaveBeenCalledTimes(1)
         expect(sleep).not.toHaveBeenCalled()
+        expect(stored.info.error?.name).toBe("MessageAbortedError")
+      } finally {
+        stream.mockRestore()
+        sleep.mockRestore()
+      }
+    })
+  })
+
+  test("does not retry aborts after assistant output has started", async () => {
+    await run(async ({ agent, msg, session, usr }) => {
+      const ctl = new AbortController()
+      const stream = spyOn(LLMModule.LLM, "stream")
+      const sleep = spyOn(RetryModule.SessionRetry, "sleep").mockResolvedValue()
+
+      try {
+        stream.mockImplementation(async (): Promise<Stream> =>
+          fail(
+            [
+              { type: "start" },
+              { type: "text-start" },
+              { type: "text-delta", text: "partial" },
+            ],
+            new DOMException("The operation was aborted.", "AbortError"),
+          ),
+        )
+
+        const result = await SessionProcessor.create({
+          assistantMessage: msg,
+          sessionID: session.id,
+          model: model(),
+          abort: ctl.signal,
+        }).process({
+          user: usr,
+          agent,
+          abort: ctl.signal,
+          sessionID: session.id,
+          system: [],
+          messages: [],
+          tools: {},
+          model: model(),
+        })
+
+        const stored = await MessageV2.get({ sessionID: session.id, messageID: msg.id })
+        if (stored.info.role !== "assistant") throw new Error("expected assistant")
+        expect(result).toBe("stop")
+        expect(stream).toHaveBeenCalledTimes(1)
+        expect(sleep).not.toHaveBeenCalled()
+        expect(stored.parts.some((part) => part.type === "text")).toBe(true)
         expect(stored.info.error?.name).toBe("MessageAbortedError")
       } finally {
         stream.mockRestore()

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -130,7 +130,7 @@ describe("session.retry.retryable", () => {
     const ctl = new AbortController()
     const error = new MessageV2.AbortedError({ message: "The operation was aborted." }).toObject()
 
-    expect(SessionRetry.retryable(error, ctl.signal)).toBe("The operation was aborted.")
+    expect(SessionRetry.retryable(error, { abort: ctl.signal, empty: true })).toBe("The operation was aborted.")
   })
 
   test("does not retry aborted errors after session cancellation", () => {
@@ -138,7 +138,14 @@ describe("session.retry.retryable", () => {
     ctl.abort()
     const error = new MessageV2.AbortedError({ message: "The operation was aborted." }).toObject()
 
-    expect(SessionRetry.retryable(error, ctl.signal)).toBeUndefined()
+    expect(SessionRetry.retryable(error, { abort: ctl.signal, empty: true })).toBeUndefined()
+  })
+
+  test("does not retry aborted errors after assistant output has started", () => {
+    const ctl = new AbortController()
+    const error = new MessageV2.AbortedError({ message: "The operation was aborted." }).toObject()
+
+    expect(SessionRetry.retryable(error, { abort: ctl.signal, empty: false })).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary
- retry unexpected `MessageAbortedError` failures only when the assistant turn is still empty
- keep interrupted turns as-is once any assistant output has already been persisted
- add focused regression coverage for both retry and no-retry abort paths

## Why
Issue #27 shows a follow-up assistant turn that was created after a successful `tool-calls` turn, emitted no parts, then later finalized as a generic aborted message. Retrying that specific zero-part abort is reasonable. Retrying after partial output is not, because it can duplicate assistant text or repeat tool side effects.

## Changes
- thread assistant-turn emptiness into `SessionRetry.retryable()` decisions
- only retry `MessageAbortedError` when the session is still active and the assistant turn has no persisted parts
- add a regression proving partial-output aborts stop instead of retrying

## Testing
- `cd packages/opencode && bun test test/session/retry.test.ts test/session/processor.test.ts`
- `cd packages/opencode && bun typecheck`

Closes #27
