### PR TITLE
fix: cap default agent steps

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -691,7 +691,7 @@ export namespace SessionPrompt {
 
       // normal processing
       const agent = await Agent.get(lastUser.agent)
-      const maxSteps = agent.steps ?? Infinity
+      const maxSteps = agent.steps ?? 200
       const isLastStep = step >= maxSteps
       msgs = await insertReminders({
         messages: msgs,


### PR DESCRIPTION
## Summary
- cap the default `agent.steps` fallback at `200` instead of `Infinity`
- align `dev` with the hard-step protection already present on `main`
- carry only the missing delta instead of replaying older doom-loop commits wholesale

## Testing
- `bun typecheck`
- `bun test --timeout 30000`

Refs #30