### PR TITLE
fix: restore local WUI recent sessions

### DIFF
--- a/packages/app/e2e/sidebar/sidebar-recent-prefetch.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-recent-prefetch.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "../fixtures"
+import { cleanupSession, openSidebar } from "../actions"
+
+test("sidebar hover prefetches lightweight session previews", async ({ page, sdk, gotoSession }) => {
+  const stamp = Date.now()
+  const one = await sdk.session.create({ title: `e2e recent prefetch 1 ${stamp}` }).then((r) => r.data)
+  const two = await sdk.session.create({ title: `e2e recent prefetch 2 ${stamp}` }).then((r) => r.data)
+
+  if (!one?.id) throw new Error("Session create did not return an id")
+  if (!two?.id) throw new Error("Session create did not return an id")
+
+  const seen: string[] = []
+  page.on("request", (req) => {
+    const url = new URL(req.url())
+    if (!url.pathname.endsWith(`/session/${two.id}/message`)) return
+    seen.push(url.searchParams.get("preview") ?? "")
+  })
+
+  try {
+    await gotoSession(one.id)
+    await openSidebar(page)
+
+    const item = page.locator(`[data-session-id="${two.id}"] a`).first()
+    await expect(item).toBeVisible()
+    await item.hover()
+
+    await expect.poll(() => seen.length, { timeout: 10_000 }).toBeGreaterThan(0)
+    expect(seen.every((value) => value === "true")).toBe(true)
+  } finally {
+    await cleanupSession({ sdk, sessionID: one.id })
+    await cleanupSession({ sdk, sessionID: two.id })
+  }
+})

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -244,6 +244,7 @@ export const GlobalRoutes = lazy(() =>
         "query",
         z.object({
           start: z.coerce.number().optional(),
+          cursor: z.coerce.number().optional(),
           search: z.string().optional(),
           limit: z.coerce.number().optional(),
           roots: z.coerce.boolean().optional(),
@@ -251,14 +252,21 @@ export const GlobalRoutes = lazy(() =>
       ),
       async (c) => {
         const query = c.req.valid("query")
+        const limit = query.limit ?? 50
         const sessions: Session.GlobalInfo[] = []
         for (const session of Session.listGlobal({
           roots: query.roots,
           start: query.start,
+          cursor: query.cursor,
           search: query.search,
-          limit: query.limit ?? 50,
+          limit: limit + 1,
         })) {
           sessions.push(session)
+        }
+        if (sessions.length > limit) {
+          const next = sessions[limit - 1]
+          sessions.length = limit
+          if (next) c.header("x-next-cursor", String(next.time.updated))
         }
         return c.json(sessions)
       },

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -53,8 +53,24 @@ type Event = { type: string; properties: Record<string, unknown> }
 
 export namespace Server {
   const log = Log.create({ service: "server" })
+  const csp =
+    "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:"
 
   export const Default = lazy(() => createApp({}))
+
+  async function webdir() {
+    const { join, resolve } = await import("path")
+    const dirs = [
+      resolve(process.cwd(), "packages/app/dist"),
+      resolve(process.cwd(), "../app/dist"),
+      resolve(process.cwd(), "app/dist"),
+      resolve(import.meta.dir, "../../../app/dist"),
+      resolve(import.meta.dir, "../../../../app/dist"),
+    ]
+    for (const dir of [...new Set(dirs)]) {
+      if (await Bun.file(join(dir, "index.html")).exists()) return dir
+    }
+  }
 
   export const createApp = (opts: { cors?: string[] }): Hono => {
     const app = new Hono()
@@ -565,31 +581,33 @@ export namespace Server {
       )
       .all("/*", async (c) => {
         const reqpath = c.req.path
-        const { resolve, join } = await import("path")
+        const { extname, join } = await import("path")
 
-        // Serve from local build if available
-        const dir = resolve(import.meta.dir, "../../../app/dist")
-        const target = reqpath === "/" ? "index.html" : reqpath.slice(1)
-        const file = Bun.file(join(dir, target))
-        if (await file.exists()) {
-          return new Response(file, {
-            headers: {
-              "Content-Type": file.type,
-              "Content-Security-Policy":
-                "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:",
-            },
-          })
-        }
-        // SPA fallback — serve index.html for client-side routes
-        const index = Bun.file(join(dir, "index.html"))
-        if (await index.exists()) {
-          return new Response(index, {
-            headers: {
-              "Content-Type": "text/html",
-              "Content-Security-Policy":
-                "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:",
-            },
-          })
+        const dir = await webdir()
+        if (dir) {
+          const target = reqpath === "/" ? "index.html" : reqpath.slice(1)
+          const file = Bun.file(join(dir, target))
+          if (await file.exists()) {
+            return new Response(file, {
+              headers: {
+                "Content-Type": file.type,
+                "Content-Security-Policy": csp,
+              },
+            })
+          }
+          // Only use SPA fallback for extensionless client-side routes.
+          if (!extname(reqpath)) {
+            const index = Bun.file(join(dir, "index.html"))
+            if (await index.exists()) {
+              return new Response(index, {
+                headers: {
+                  "Content-Type": "text/html",
+                  "Content-Security-Policy": csp,
+                },
+              })
+            }
+          }
+          return new Response("Not Found", { status: 404 })
         }
 
         const response = await proxy(`https://app.opencode.ai${reqpath}`, {
@@ -601,7 +619,7 @@ export namespace Server {
         })
         response.headers.set(
           "Content-Security-Policy",
-          "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:",
+          csp,
         )
         return response
       })

--- a/packages/opencode/test/server/global-session-route.test.ts
+++ b/packages/opencode/test/server/global-session-route.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test"
+import { Server } from "../../src/server/server"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+describe("global.session route", () => {
+  test("returns x-next-cursor and respects cursor pagination", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const first = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => Session.create({ title: "route-page-one" }),
+    })
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    const second = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => Session.create({ title: "route-page-two" }),
+    })
+
+    const app = Server.Default()
+
+    const page1 = await app.request("/global/session?roots=true&limit=1")
+    expect(page1.status).toBe(200)
+    const firstBody = (await page1.json()) as Array<{ id: string; time: { updated: number } }>
+    expect(firstBody).toHaveLength(1)
+    expect(firstBody[0]?.id).toBe(second.id)
+
+    const cursor = page1.headers.get("x-next-cursor")
+    expect(cursor).toBeTruthy()
+
+    const page2 = await app.request(`/global/session?roots=true&limit=1&cursor=${encodeURIComponent(cursor!)}`)
+    expect(page2.status).toBe(200)
+    const secondBody = (await page2.json()) as Array<{ id: string }>
+    expect(secondBody).toHaveLength(1)
+    expect(secondBody[0]?.id).toBe(first.id)
+  })
+})

--- a/packages/opencode/test/server/static-app.test.ts
+++ b/packages/opencode/test/server/static-app.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { mkdir } from "fs/promises"
+import { Server } from "../../src/server/server"
+import { Instance } from "../../src/project/instance"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+async function setup(root: string) {
+  await mkdir(path.join(root, "packages/app/dist/assets"), { recursive: true })
+  await Bun.write(path.join(root, "packages/app/dist/index.html"), "<!doctype html><title>local app</title>")
+  await Bun.write(path.join(root, "packages/app/dist/assets/session-test.js"), "console.log('ok')")
+}
+
+async function check<T>(fn: (app: ReturnType<typeof Server.createApp>, root: string) => Promise<T>) {
+  await using tmp = await tmpdir()
+  await setup(tmp.path)
+  const cwd = process.cwd()
+  try {
+    process.chdir(tmp.path)
+    return await fn(Server.createApp({}), tmp.path)
+  } finally {
+    process.chdir(cwd)
+    await Instance.disposeAll()
+  }
+}
+
+describe("server static app", () => {
+  test("serves local asset files from repo app dist", async () => {
+    await check(async (app) => {
+      const res = await app.request("/assets/session-test.js")
+      expect(res.status).toBe(200)
+      expect(res.headers.get("content-type")).toContain("javascript")
+      expect(await res.text()).toContain("console.log('ok')")
+    })
+  })
+
+  test("uses SPA fallback for extensionless routes only", async () => {
+    await check(async (app) => {
+      const res = await app.request("/recent")
+      expect(res.status).toBe(200)
+      expect(res.headers.get("content-type")).toContain("text/html")
+      expect(await res.text()).toContain("<title>local app</title>")
+    })
+  })
+
+  test("does not return index.html for missing asset files", async () => {
+    await check(async (app) => {
+      const res = await app.request("/assets/missing.js")
+      expect(res.status).toBe(404)
+      expect(await res.text()).toBe("Not Found")
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- fix local `opencode serve` app-dist resolution and stop serving `index.html` for missing asset files
- restore `/global/session` cursor pagination headers used by the recent-sessions UI
- consolidate regression coverage for static asset serving, global-session pagination, and recent-session hover prefetch

## Testing
- `bun test --timeout 30000 test/server/static-app.test.ts test/server/global-session-route.test.ts test/server/global-session-list.test.ts`
- `bun run test:e2e:local -- e2e/sidebar/sidebar-recent-prefetch.spec.ts`
- `bun typecheck` in `packages/opencode`
- `bun typecheck` in `packages/app`
- `bun run install:local`
- manual live verification on `http://127.0.0.1:4096`

Closes #34