### PR TITLE
Fix workspace visibility for existing worktrees

### DIFF
--- a/packages/app/e2e/projects/workspaces.spec.ts
+++ b/packages/app/e2e/projects/workspaces.spec.ts
@@ -18,7 +18,7 @@ import {
   waitSlug,
 } from "../actions"
 import { dropdownMenuContentSelector, inlineInputSelector, workspaceItemSelector } from "../selectors"
-import { createSdk, dirSlug } from "../utils"
+import { createSdk, dirSlug, resolveDirectory } from "../utils"
 
 async function setupWorkspaceTest(page: Page, project: { slug: string }) {
   const rootSlug = project.slug
@@ -66,6 +66,33 @@ test("can enable and disable workspaces from project menu", async ({ page, withP
     await setWorkspacesEnabled(page, slug, false)
     await expect(page.getByRole("button", { name: "New session" }).first()).toBeVisible()
     await expect(page.locator(workspaceItemSelector(slug))).toHaveCount(0)
+  })
+})
+
+test("existing workspaces auto-show after reload", async ({ page, withProject }) => {
+  await page.setViewportSize({ width: 1400, height: 800 })
+
+  await withProject(async (project) => {
+    const sdk = createSdk(project.directory)
+    const created = await sdk.worktree.create({ directory: project.directory }).then((x) => x.data)
+    if (!created?.directory) throw new Error("Failed to create workspace")
+    project.trackDirectory(created.directory)
+
+    const raw = dirSlug(created.directory)
+    const resolved = dirSlug(await resolveDirectory(created.directory))
+
+    await page.reload()
+    await openSidebar(page)
+
+    await expect(page.getByRole("button", { name: "New workspace" }).first()).toBeVisible()
+    const item = page.locator(`${workspaceItemSelector(resolved)}, ${workspaceItemSelector(raw)}`).first()
+    await expect(item).toBeVisible()
+
+    await setWorkspacesEnabled(page, project.slug, false)
+    await expect(item).toHaveCount(0)
+
+    await setWorkspacesEnabled(page, project.slug, true)
+    await expect(page.locator(`${workspaceItemSelector(resolved)}, ${workspaceItemSelector(raw)}`).first()).toBeVisible()
   })
 })
 

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -377,6 +377,10 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
 
     const [colors, setColors] = createStore<Record<string, AvatarColorKey>>({})
     const colorRequested = new Map<string, AvatarColorKey>()
+    const auto = (directory: string) => {
+      const item = globalSync.data.project.find((x) => x.worktree === directory)
+      return item?.vcs === "git" && (item.sandboxes?.length ?? 0) > 0
+    }
 
     function pickAvailableColor(used: Set<string>): AvatarColorKey {
       const available = AVATAR_COLOR_KEYS.filter((c) => !used.has(c))
@@ -600,13 +604,19 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
           setStore("sidebar", "width", width)
         },
         workspaces(directory: string) {
-          return () => store.sidebar.workspaces[directory] ?? store.sidebar.workspacesDefault ?? false
+          return () => {
+            const value = store.sidebar.workspaces[directory]
+            if (value !== undefined) return value
+            if (auto(directory)) return true
+            return store.sidebar.workspacesDefault ?? false
+          }
         },
         setWorkspaces(directory: string, value: boolean) {
           setStore("sidebar", "workspaces", directory, value)
         },
         toggleWorkspaces(directory: string) {
-          const current = store.sidebar.workspaces[directory] ?? store.sidebar.workspacesDefault ?? false
+          const current =
+            store.sidebar.workspaces[directory] ?? (auto(directory) ? true : (store.sidebar.workspacesDefault ?? false))
           setStore("sidebar", "workspaces", directory, !current)
         },
       },


### PR DESCRIPTION
## Summary
- auto-show workspace mode for git projects that already have discovered sandboxes when no explicit per-project override exists
- preserve explicit disable/enable behavior by toggling from the effective current workspace state
- add e2e regression coverage for existing workspaces after reload and for disable/re-enable from that state

## Testing
- `bun typecheck` in `packages/app`
- `bun run test:e2e:local -- e2e/projects/workspaces.spec.ts`

Closes #41