### PR TITLE
fix(app): add requestMicrophoneAccess to Platform type

### DIFF
--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -87,6 +87,9 @@ export type Platform = {
 
   /** Read image from clipboard (desktop only) */
   readClipboardImage?(): Promise<File | null>
+
+  /** Request microphone access (desktop only) */
+  requestMicrophoneAccess?(): Promise<boolean>
 }
 
 export type DisplayBackend = "auto" | "wayland"


### PR DESCRIPTION
## Summary

- Add optional `requestMicrophoneAccess?(): Promise<boolean>` to the `Platform` type in `packages/app/src/context/platform.tsx`
- The electron renderer already implements this method but the shared type was missing the field, causing a typecheck failure in `desktop-electron`