### PR TITLE
feat(app): add tree view indentation for sandbox worktrees

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -2270,6 +2270,7 @@ export default function Layout(props: ParentProps) {
                                 sortNow={sortNow}
                                 mobile={panelProps.mobile}
                                 popover={popover()}
+                                depth={directory === project()!.worktree ? 0 : 1}
                               />
                             )}
                           </For>

--- a/packages/app/src/pages/layout/sidebar-project.tsx
+++ b/packages/app/src/pages/layout/sidebar-project.tsx
@@ -230,8 +230,9 @@ const ProjectPreviewPanel = (props: {
           {(directory) => {
             const sessions = createMemo(() => props.workspaceSessions(directory))
             const children = createMemo(() => props.workspaceChildren(directory))
+            const sandbox = () => directory !== props.project.worktree
             return (
-              <div class="flex flex-col gap-1">
+              <div class="flex flex-col gap-1" style={{ "padding-left": sandbox() ? "12px" : undefined }}>
                 <div class="px-2 py-0.5 flex items-center gap-1 min-w-0">
                   <div class="shrink-0 size-6 flex items-center justify-center">
                     <Icon name="branch" size="small" class="text-icon-base" />

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -308,6 +308,7 @@ export const SortableWorkspace = (props: {
   sortNow: Accessor<number>
   mobile?: boolean
   popover?: boolean
+  depth?: number
 }): JSX.Element => {
   const navigate = useNavigate()
   const params = useParams()
@@ -373,6 +374,8 @@ export const SortableWorkspace = (props: {
     globalSync.child(props.directory, { bootstrap: true })
   })
 
+  const depth = () => props.depth ?? 0
+
   return (
     <div
       // @ts-ignore
@@ -381,6 +384,7 @@ export const SortableWorkspace = (props: {
         "opacity-30": sortable.isActiveDraggable,
         "opacity-50 pointer-events-none": busy(),
       }}
+      style={{ "padding-left": depth() > 0 ? `${depth() * 12}px` : undefined }}
     >
       <Collapsible variant="ghost" open={open()} class="shrink-0" onOpenChange={openWrapper}>
         <div class="py-1">


### PR DESCRIPTION
## Summary

- Sandbox worktrees are now visually indented under their parent project worktree in the sidebar
- Adds a `depth` prop to `SortableWorkspace` (0 for main worktree, 1 for sandboxes)
- Applies `padding-left` indentation for sandboxes in both the expanded workspace view and the collapsed project preview panel

Companion to #54 (session tree view). Together they complete the tree view rendering for both sessions and worktrees.