### PR TITLE
fix(app): only check last message for session working indicator

### DIFF
--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -217,17 +217,13 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
   })
   const isWorking = createMemo(() => {
     if (hasPermissions()) return false
-    const pending = (sessionStore.message[props.session.id] ?? []).findLast(
-      (message) =>
-        message.role === "assistant" &&
-        typeof (message as { time?: { completed?: unknown } }).time?.completed !== "number",
-    )
+    const msgs = sessionStore.message[props.session.id] ?? []
+    const last = msgs[msgs.length - 1]
+    const pending =
+      last?.role === "assistant" && typeof (last as { time?: { completed?: unknown } }).time?.completed !== "number"
     const status = sessionStore.session_status[props.session.id]
     return (
-      pending !== undefined ||
-      status?.type === "busy" ||
-      status?.type === "retry" ||
-      (status !== undefined && status.type !== "idle")
+      pending || status?.type === "busy" || status?.type === "retry" || (status !== undefined && status.type !== "idle")
     )
   })
 

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -249,11 +249,12 @@ export function MessageTimeline(props: {
     if (!id) return emptyMessages
     return sync.data.message[id] ?? emptyMessages
   })
-  const pending = createMemo(() =>
-    sessionMessages().findLast(
-      (item): item is AssistantMessage => item.role === "assistant" && typeof item.time.completed !== "number",
-    ),
-  )
+  const pending = createMemo(() => {
+    const msgs = sessionMessages()
+    const last = msgs[msgs.length - 1]
+    if (last?.role === "assistant" && typeof last.time.completed !== "number") return last as AssistantMessage
+    return undefined
+  })
   const sessionStatus = createMemo(() => {
     const id = sessionID()
     if (!id) return idle


### PR DESCRIPTION
## Summary

- Fixes sessions appearing permanently "in progress" (spinning indicator) when they are actually idle
- Root cause: `findLast` scanned **all** messages for any incomplete assistant response, so an orphaned message deep in history (with no `time.completed`) would make the session appear busy forever
- Fix: only check the **very last** message — if it's an incomplete assistant message, the session is working; otherwise it's idle

## Changed files

- `packages/app/src/pages/layout/sidebar-items.tsx` — `isWorking` memo now checks only the last message instead of using `findLast`
- `packages/app/src/pages/session/message-timeline.tsx` — `pending` memo uses the same last-message-only check, fixing both the sidebar spinner and the in-session "Thinking" indicator