### PR TITLE
fix(session): recover orphaned assistant messages on startup

### DIFF
--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -11,9 +11,11 @@ import { Command } from "../command"
 import { Instance } from "./instance"
 import { Log } from "@/util/log"
 import { ShareNext } from "@/share/share-next"
+import { Session } from "@/session"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
+  await Session.recover()
   await Plugin.init()
   ShareNext.init()
   Format.init()

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -9,7 +9,7 @@ import { Config } from "../config/config"
 import { Flag } from "../flag/flag"
 import { Installation } from "../installation"
 
-import { Database, NotFoundError, eq, and, or, gte, isNull, desc, like, inArray, lt } from "../storage/db"
+import { Database, NotFoundError, eq, and, or, gte, isNull, desc, like, inArray, lt, sql } from "../storage/db"
 import type { SQL } from "../storage/db"
 import { SessionTable, MessageTable, PartTable } from "./session.sql"
 import { ProjectTable } from "../project/project.sql"
@@ -866,6 +866,57 @@ export namespace Session {
       }
     },
   )
+
+  /**
+   * Recover orphaned assistant messages left incomplete after a server crash or restart.
+   * Finds assistant messages with no `time.completed`, forces their non-terminal tool
+   * parts to error status, marks the messages as completed, and emits bus events so
+   * connected frontends update.
+   *
+   * @see https://github.com/anomalyco/opencode/issues/19023
+   */
+  export async function recover() {
+    const rows = Database.use((db) =>
+      db
+        .select()
+        .from(MessageTable)
+        .where(
+          and(
+            sql`json_extract(${MessageTable.data}, '$.role') = 'assistant'`,
+            sql`json_extract(${MessageTable.data}, '$.time.completed') is null`,
+          ),
+        )
+        .all(),
+    )
+    if (rows.length === 0) return
+    log.info("recovering orphaned assistant messages", { count: rows.length })
+    const now = Date.now()
+    for (const row of rows) {
+      const msg = { ...row.data, id: row.id, sessionID: row.session_id } as MessageV2.Assistant
+      // Fix non-terminal tool parts
+      const parts = await MessageV2.parts(row.id)
+      for (const part of parts) {
+        if (part.type !== "tool") continue
+        if (part.state.status === "completed" || part.state.status === "error") continue
+        await updatePart({
+          ...part,
+          state: {
+            ...part.state,
+            status: "error",
+            error: "Tool execution was interrupted by server restart",
+            time: {
+              start: part.state.status === "running" ? part.state.time.start : now,
+              end: now,
+            },
+          },
+        })
+      }
+      // Mark message completed
+      msg.time.completed = now
+      await updateMessage(msg)
+      log.info("recovered orphaned message", { messageID: row.id, sessionID: row.session_id })
+    }
+  }
 
   export class BusyError extends Error {
     constructor(public readonly sessionID: string) {


### PR DESCRIPTION
## Summary

When the OpenCode server crashes or restarts while a session is actively executing tool calls, sessions get permanently stuck in a "Thinking" state. This happens because:

1. In-memory `SessionStatus` map is lost on restart
2. Database retains stale state: assistant messages with `time.completed = undefined` and tool parts stuck in `running`/`pending` status
3. No startup recovery mechanism exists to clean up these orphaned messages

## Changes

- **`packages/opencode/src/session/index.ts`** — Add `Session.recover()` function that:
  - Queries assistant messages where `time.completed` is null (orphaned)
  - Forces `running`/`pending` tool parts to `error` status with descriptive message
  - Marks orphaned messages as completed (`time.completed = Date.now()`)
  - Emits bus events so connected frontends update automatically

- **`packages/opencode/src/project/bootstrap.ts`** — Wire `Session.recover()` into `InstanceBootstrap()` so it runs early on every server start, before plugins and other init

## Design

The implementation mirrors the existing post-stream cleanup pattern in `processor.ts:402-417` which forces non-terminal tool parts to error after a stream ends. That code only runs if the process survives to reach it — this patch covers the crash/restart case.

The function is idempotent: on a clean startup with no orphaned messages, it's a single no-op query.

## Testing

- `bun typecheck` passes (no new errors introduced)
- Manually verified on a local instance with stuck sessions in the database

## Related

- Upstream issue: https://github.com/anomalyco/opencode/issues/19023
- Related upstream issues: #17680, #16856, #14769, #11865, #13841
- Supersedes closed PR #26 (rebased onto current main)