### PR TITLE
feat: redesign recent sessions as pinned sidebar tab

### DIFF
--- a/packages/app/e2e/sidebar/sidebar-recent-panel.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-recent-panel.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "../fixtures"
+import { cleanupTestProject, createTestProject, openSidebar } from "../actions"
+import { sessionItemSelector } from "../selectors"
+import { createSdk } from "../utils"
+
+test("recent sidebar tile shows global sessions across projects", async ({ page, withProject }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+
+  const other = await createTestProject()
+
+  try {
+    await withProject(
+      async ({ directory: root, gotoSession, trackSession }) => {
+        const stamp = Date.now()
+        const firstTitle = `e2e recent root ${stamp}`
+        const secondTitle = `e2e recent other ${stamp}`
+
+        const first = await createSdk(root).session.create({ title: firstTitle }).then((r) => r.data)
+        const second = await createSdk(other).session.create({ title: secondTitle }).then((r) => r.data)
+
+        if (!first?.id) throw new Error("Session create did not return an id")
+        if (!second?.id) throw new Error("Session create did not return an id")
+
+        trackSession(first.id, root)
+        trackSession(second.id, other)
+
+        await gotoSession(first.id)
+        await openSidebar(page)
+
+        const tile = page.locator('[data-component="sidebar-rail"]').getByRole("button", { name: /recent sessions/i })
+        await expect(tile).toBeVisible()
+        await tile.click()
+
+        const nav = page.locator('[data-component="sidebar-nav-desktop"]').first()
+        await expect(nav.getByText("Across all projects").first()).toBeVisible()
+
+        const input = nav.getByPlaceholder(/search/i).first()
+        await expect(input).toBeVisible()
+
+        const one = page.locator(sessionItemSelector(first.id)).first()
+        const two = page.locator(sessionItemSelector(second.id)).first()
+
+        await expect(one).toBeVisible()
+        await expect(two).toBeVisible()
+
+        await input.fill(secondTitle)
+        await expect(two).toBeVisible()
+        await expect(one).toHaveCount(0)
+
+        await input.fill("")
+        await expect(one).toBeVisible()
+        await expect(two).toBeVisible()
+      },
+      { extra: [other] },
+    )
+  } finally {
+    await cleanupTestProject(other)
+  }
+})

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -705,6 +705,9 @@ export const dict = {
   "sidebar.project.clearNotifications": "Clear notifications",
   "sidebar.empty.title": "No projects open",
   "sidebar.empty.description": "Open a project to get started",
+  "sidebar.recent.description": "Across all projects",
+  "common.search": "Search",
+  "common.noResults": "No results",
 
   "debugBar.ariaLabel": "Development performance diagnostics",
   "debugBar.na": "n/a",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -91,6 +91,7 @@ import {
 } from "./layout/sidebar-workspace"
 import { ProjectDragOverlay, SortableProject, type ProjectSidebarContext } from "./layout/sidebar-project"
 import { SidebarContent } from "./layout/sidebar-shell"
+import { RecentTile, RecentSidebarPanel } from "./layout/sidebar-recent"
 
 export default function Layout(props: ParentProps) {
   const [store, setStore, , ready] = persisted(
@@ -160,6 +161,7 @@ export default function Layout(props: ParentProps) {
     sizing: false,
     peek: undefined as string | undefined,
     peeked: false,
+    recent: false,
   })
 
   const editor = createInlineEditorController()
@@ -1273,6 +1275,7 @@ export default function Layout(props: ParentProps) {
 
   async function navigateToProject(directory: string | undefined) {
     if (!directory) return
+    setState("recent", false)
     const root = projectRoot(directory)
     server.projects.touch(root)
     const project = layout.projects.list().find((item) => item.worktree === root)
@@ -2323,6 +2326,18 @@ export default function Layout(props: ParentProps) {
     )
   }
 
+  const recentSessionProps: typeof projectSidebarCtx.sessionProps = {
+    navList: currentSessions,
+    sidebarExpanded,
+    sidebarHovering,
+    nav: () => state.nav,
+    hoverSession: () => state.hoverSession,
+    setHoverSession,
+    clearHoverProjectSoon,
+    prefetchSession,
+    archiveSession,
+  }
+
   const projects = () => layout.projects.list()
   const projectOverlay = () => <ProjectDragOverlay projects={projects} activeProject={() => store.activeProject} />
   const sidebarContent = (mobile?: boolean) => (
@@ -2346,10 +2361,28 @@ export default function Layout(props: ParentProps) {
       onOpenSettings={openSettings}
       helpLabel={() => language.t("sidebar.help")}
       onOpenHelp={() => platform.openLink("https://opencode.ai/desktop-feedback")}
-      recentLabel={() => "Recently Active"}
-      onOpenRecent={() => navigate("/recent")}
+      renderRecentTile={() => (
+        <RecentTile
+          selected={() => state.recent}
+          onClick={() => {
+            setState("recent", true)
+            layout.sidebar.open()
+          }}
+        />
+      )}
       renderPanel={() =>
-        mobile ? <SidebarPanel project={currentProject} mobile /> : <SidebarPanel project={currentProject} merged />
+        state.recent ? (
+          <RecentSidebarPanel
+            mobile={mobile}
+            merged={mobile ? undefined : layout.sidebar.opened() ? true : undefined}
+            sessionProps={recentSessionProps}
+            sidebarWidth={() => layout.sidebar.width()}
+            sidebarOpened={() => layout.sidebar.opened()}
+            sidebarHovering={sidebarHovering}
+          />
+        ) : (
+          mobile ? <SidebarPanel project={currentProject} mobile /> : <SidebarPanel project={currentProject} merged />
+        )
       }
     />
   )

--- a/packages/app/src/pages/layout/sidebar-recent.tsx
+++ b/packages/app/src/pages/layout/sidebar-recent.tsx
@@ -1,0 +1,204 @@
+import { createEffect, createMemo, For, on, Show, type Accessor, type JSX } from "solid-js"
+import { createStore } from "solid-js/store"
+import { base64Encode } from "@opencode-ai/util/encode"
+import { Button } from "@opencode-ai/ui/button"
+import { Icon } from "@opencode-ai/ui/icon"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
+import { type GlobalSession } from "@opencode-ai/sdk/v2/client"
+import { useGlobalSDK } from "@/context/global-sdk"
+import { useLanguage } from "@/context/language"
+import { SessionItem, SessionSkeleton, type SessionItemProps } from "./sidebar-items"
+
+const LIMIT = 20
+
+async function query(
+  client: ReturnType<typeof useGlobalSDK>["client"],
+  opts: { search?: string; cursor?: number; limit?: number },
+) {
+  const result = await client.global.session
+    .list({
+      roots: true,
+      limit: opts.limit ?? LIMIT,
+      search: opts.search,
+      cursor: opts.cursor,
+    })
+    .catch(() => undefined)
+  const next = result?.response.headers.get("x-next-cursor")
+  return { items: result?.data ?? [], next: next ? Number(next) : undefined }
+}
+
+export const RecentTile = (props: {
+  selected: Accessor<boolean>
+  onClick: () => void
+}): JSX.Element => {
+  const language = useLanguage()
+  return (
+    <Tooltip placement="right" value={language.t("sidebar.project.recentSessions")}>
+      <button
+        type="button"
+        aria-label={language.t("sidebar.project.recentSessions")}
+        classList={{
+          "flex items-center justify-center size-10 p-1 rounded-lg overflow-hidden transition-colors cursor-default":
+            true,
+          "bg-transparent border-2 border-icon-strong-base hover:bg-surface-base-hover": props.selected(),
+          "bg-transparent border border-transparent hover:bg-surface-base-hover hover:border-border-weak-base":
+            !props.selected(),
+        }}
+        onClick={props.onClick}
+      >
+        <div class="size-8 rounded flex items-center justify-center bg-surface-base-hover">
+          <Icon name="status" class="text-icon-base" />
+        </div>
+      </button>
+    </Tooltip>
+  )
+}
+
+export const RecentSidebarPanel = (props: {
+  mobile?: boolean
+  merged?: boolean
+  sessionProps: Omit<SessionItemProps, "session" | "list" | "slug" | "children" | "mobile" | "dense" | "popover">
+  sidebarWidth: Accessor<number>
+  sidebarOpened: Accessor<boolean>
+  sidebarHovering: Accessor<boolean>
+}): JSX.Element => {
+  const globalSDK = useGlobalSDK()
+  const language = useLanguage()
+  const merged = createMemo(() => props.mobile || (props.merged ?? props.sidebarOpened()))
+  const hover = createMemo(() => !props.mobile && props.merged === false && !props.sidebarOpened())
+  const popover = createMemo(() => !!props.mobile || props.merged === false || props.sidebarOpened())
+
+  const [store, setStore] = createStore({
+    sessions: [] as GlobalSession[],
+    loading: true,
+    cursor: undefined as number | undefined,
+    search: "",
+    booted: false,
+  })
+
+  const children = createMemo(() => {
+    const map = new Map<string, string[]>()
+    for (const session of store.sessions) {
+      if (!session.parentID) continue
+      const list = map.get(session.parentID) ?? []
+      list.push(session.id)
+      map.set(session.parentID, list)
+    }
+    return map
+  })
+
+  const roots = createMemo(() => store.sessions.filter((s) => !s.parentID))
+
+  const load = async (reset?: boolean) => {
+    setStore("loading", true)
+    const result = await query(globalSDK.client, {
+      search: store.search || undefined,
+      cursor: reset ? undefined : store.cursor,
+      limit: LIMIT,
+    })
+    if (reset) {
+      setStore("sessions", result.items)
+    } else {
+      setStore("sessions", (prev) => [...prev, ...result.items])
+    }
+    setStore("cursor", result.next)
+    setStore("loading", false)
+    setStore("booted", true)
+  }
+
+  createEffect(
+    on(
+      () => store.search,
+      () => load(true),
+    ),
+  )
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const onSearch = (val: string) => {
+    clearTimeout(timer)
+    timer = setTimeout(() => setStore("search", val), 300)
+  }
+
+  const slug = (session: GlobalSession) => base64Encode(session.directory)
+
+  return (
+    <div
+      classList={{
+        "flex flex-col min-h-0 min-w-0 box-border rounded-tl-[12px] px-3": true,
+        "border border-b-0 border-border-weak-base": !merged(),
+        "border-l border-t border-border-weaker-base": merged(),
+        "bg-background-base": merged() || hover(),
+        "bg-background-stronger": !merged() && !hover(),
+        "flex-1 min-w-0": props.mobile,
+        "max-w-full overflow-hidden": props.mobile,
+      }}
+      style={{
+        width: props.mobile ? undefined : `${Math.max(Math.max(props.sidebarWidth(), 244) - 64, 0)}px`,
+      }}
+    >
+      <div class="shrink-0 pl-1 py-1">
+        <div class="flex items-start justify-between gap-2 py-2 pl-2 pr-0">
+          <div class="flex flex-col min-w-0">
+            <span class="text-14-medium text-text-strong truncate">
+              {language.t("sidebar.project.recentSessions")}
+            </span>
+            <span class="text-12-regular text-text-base truncate">{language.t("sidebar.recent.description")}</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="shrink-0 px-1 pb-2">
+        <input
+          type="text"
+          placeholder={`${language.t("common.search")}...`}
+          class="w-full px-3 py-1.5 text-14-regular bg-transparent border border-border rounded-md text-text-strong placeholder:text-text-weak focus:outline-none focus:border-text-weak"
+          onInput={(e) => onSearch(e.currentTarget.value)}
+        />
+      </div>
+
+      <div class="flex-1 min-h-0 overflow-y-auto no-scrollbar [overflow-anchor:none] py-2">
+        <Show when={store.loading && !store.booted}>
+          <SessionSkeleton />
+        </Show>
+
+        <Show when={store.booted && roots().length === 0 && !store.loading}>
+          <div class="flex items-center justify-center py-8 text-text-weak text-14-regular">
+            {language.t("common.noResults")}
+          </div>
+        </Show>
+
+        <nav class="flex flex-col gap-1">
+          <For each={roots()}>
+            {(session) => (
+              <SessionItem
+                {...props.sessionProps}
+                session={session}
+                list={roots()}
+                slug={slug(session)}
+                mobile={props.mobile}
+                popover={popover()}
+                children={children()}
+              />
+            )}
+          </For>
+
+          <Show when={store.cursor !== undefined && !store.loading}>
+            <div class="relative w-full py-1">
+              <Button
+                variant="ghost"
+                class="flex w-full text-left justify-start text-14-regular text-text-weak pl-9 pr-10"
+                size="large"
+                onClick={(e: MouseEvent) => {
+                  load()
+                  ;(e.currentTarget as HTMLButtonElement).blur()
+                }}
+              >
+                {language.t("common.loadMore")}
+              </Button>
+            </div>
+          </Show>
+        </nav>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/pages/layout/sidebar-shell.tsx
+++ b/packages/app/src/pages/layout/sidebar-shell.tsx
@@ -30,8 +30,7 @@ export const SidebarContent = (props: {
   onOpenSettings: () => void
   helpLabel: Accessor<string>
   onOpenHelp: () => void
-  recentLabel: Accessor<string>
-  onOpenRecent: () => void
+  renderRecentTile: () => JSX.Element
   renderPanel: () => JSX.Element
 }): JSX.Element => {
   const expanded = createMemo(() => !!props.mobile || props.opened())
@@ -65,6 +64,7 @@ export const SidebarContent = (props: {
             <DragDropSensors />
             <ConstrainDragXAxis />
             <div class="h-full w-full flex flex-col items-center gap-3 px-3 py-3 overflow-y-auto no-scrollbar">
+              {props.renderRecentTile()}
               <SortableProvider ids={props.projects().map((p) => p.worktree)}>
                 <For each={props.projects()}>{(project) => props.renderProject(project)}</For>
               </SortableProvider>
@@ -92,15 +92,6 @@ export const SidebarContent = (props: {
           </DragDropProvider>
         </div>
         <div class="shrink-0 w-full pt-3 pb-6 flex flex-col items-center gap-2">
-          <Tooltip placement={placement()} value={props.recentLabel()}>
-            <IconButton
-              icon="status"
-              variant="ghost"
-              size="large"
-              onClick={props.onOpenRecent}
-              aria-label={props.recentLabel()}
-            />
-          </Tooltip>
           <TooltipKeybind placement={placement()} title={props.settingsLabel()} keybind={props.settingsKeybind() ?? ""}>
             <IconButton
               icon="settings-gear"

--- a/packages/app/src/pages/recent.tsx
+++ b/packages/app/src/pages/recent.tsx
@@ -2,6 +2,7 @@ import { createResource, createSignal, For, Show, createMemo } from "solid-js"
 import { useNavigate } from "@solidjs/router"
 import { Icon } from "@opencode-ai/ui/icon"
 import { base64Encode } from "@opencode-ai/util/encode"
+import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { DateTime } from "luxon"
 
@@ -30,15 +31,20 @@ function flatten(roots: RecentSession[], children: Map<string, RecentSession[]>)
 
 export default function Recent() {
   const navigate = useNavigate()
+  const globalSDK = useGlobalSDK()
   const sync = useGlobalSync()
   const [search, setSearch] = createSignal("")
 
   const [sessions] = createResource(
     () => search(),
     async (query) => {
-      const res = await fetch(`/global/session?limit=100${query ? `&search=${encodeURIComponent(query)}` : ""}`)
-      if (!res.ok) return []
-      return res.json() as Promise<RecentSession[]>
+      return globalSDK.client.global.session
+        .list({
+          limit: 100,
+          search: query || undefined,
+        })
+        .then((x) => (x.data ?? []) as RecentSession[])
+        .catch(() => [])
     },
   )
 


### PR DESCRIPTION
## Summary
- add the pinned `Recent sessions` rail tile and sidebar panel on `main`
- load global recent sessions through the SDK so both the sidebar panel and `/recent` fallback work in local web flows
- add focused e2e coverage for cross-project recent sessions and search

## Linked issue
- Refs anomalyco/opencode#19170

## Validation
- `cd packages/app && bun typecheck`
- `cd packages/app && bun test:e2e:local -- e2e/sidebar/sidebar-recent-panel.spec.ts`
- `cd packages/app && bun test:e2e:local -- e2e/sidebar/sidebar-recent-prefetch.spec.ts e2e/sidebar/sidebar-recent-panel.spec.ts`