### PR TITLE
fix: handle symlinked local install target

### DIFF
--- a/packages/opencode/script/install-local.ts
+++ b/packages/opencode/script/install-local.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { $ } from "bun"
+import fs from "fs/promises"
 import path from "path"
 
 const dir = path.resolve(import.meta.dir, "..")
@@ -8,14 +9,18 @@ const os = process.platform === "win32" ? "windows" : process.platform
 const arch = process.arch === "x64" ? "x64" : process.arch === "arm64" ? "arm64" : process.arch
 const src = path.join(dir, "dist", `opencode-${os}-${arch}`, "bin", os === "windows" ? "opencode.exe" : "opencode")
 const dst = path.join(process.env.HOME || "", ".local", "bin", os === "windows" ? "opencode.exe" : "opencode")
+const tmp = `${dst}.${process.pid}.tmp`
 
 process.chdir(dir)
 
-await $`mkdir -p ${path.dirname(dst)}`
-await $`cp ${src} ${dst}`
+await fs.mkdir(path.dirname(dst), { recursive: true })
+await fs.rm(tmp, { force: true })
+await fs.copyFile(src, tmp)
+await fs.rm(dst, { force: true })
+await fs.rename(tmp, dst)
 
 if (os !== "windows") {
-  await $`chmod +x ${dst}`
+  await fs.chmod(dst, 0o755)
 }
 
 if (os === "darwin") {


### PR DESCRIPTION
## Summary

Fix `bun run install:local` when `~/.local/bin/opencode` is already a symlink to the current build artifact.

The installer now copies through a temporary path, removes any existing destination file or symlink, and renames the staged binary into place before applying chmod/codesign.

Fixes #67.

## Validation

- `cd packages/opencode && bun typecheck`
- `cd packages/opencode && bun run install:local`
- `/Users/engineer/.local/bin/opencode --version`
- `git push -u origin fix/67-install-local-samefile` (repo pre-push hook ran `bun turbo typecheck` successfully)
