### PR TITLE
fix: restore local serve recent sessions

### DIFF
--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -100,12 +100,9 @@ if (!(root instanceof HTMLElement) && import.meta.env.DEV) {
 const localUrl = () =>
   `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
 
-const isLocalHost = () => ["localhost", "127.0.0.1", "0.0.0.0"].includes(location.hostname)
-
 const getCurrentUrl = () => {
   if (location.hostname.includes("opencode.ai")) return localUrl()
   if (import.meta.env.DEV) return localUrl()
-  if (isLocalHost()) return localUrl()
   return location.origin
 }
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -13,7 +13,7 @@
     "build:local": "OPENCODE_CHANNEL=local bun run build --single",
     "sign:local": "bun run script/sign-local.ts",
     "copy:local": "bun run script/install-local.ts",
-    "install:local": "bun run build:local && bun run sign:local && bun run copy:local",
+    "install:local": "bun run --cwd ../app build && bun run build:local && bun run sign:local && bun run copy:local",
     "profile:memory": "bun run script/memory-profile.ts",
     "dev": "bun run --conditions=browser ./src/index.ts",
     "random": "echo 'Random script updated at $(date)' && echo 'Change queued successfully' && echo 'Another change made' && echo 'Yet another change' && echo 'One more change' && echo 'Final change' && echo 'Another final change' && echo 'Yet another final change'",


### PR DESCRIPTION
## Summary

This fixes two separate local `opencode serve` regressions:

- `install:local` now builds `packages/app` so the local server does not silently fall back to the deployed web app
- the served web app now keeps `location.origin` for production local origins instead of rewriting `127.0.0.1` to `localhost`

Together these restore the recent sessions UI when running the installed local binary.

Closes #71
Closes #72

## Verification

- `bun run install:local`
- `~/.local/bin/opencode serve --hostname 127.0.0.1 --port 4096`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:4096 PLAYWRIGHT_SERVER_HOST=127.0.0.1 PLAYWRIGHT_SERVER_PORT=4096 bun test:e2e -- sidebar/sidebar-recent-panel.spec.ts`
- `~/.local/bin/opencode serve --hostname 100.68.120.26 --port 4096`
- `PLAYWRIGHT_BASE_URL=http://100.68.120.26:4096 PLAYWRIGHT_SERVER_HOST=100.68.120.26 PLAYWRIGHT_SERVER_PORT=4096 bun test:e2e -- sidebar/sidebar-recent-panel.spec.ts`
