### PR TITLE
feat: merge remaining local Edge TTS branch into main

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -368,6 +368,7 @@
         "jsonc-parser": "3.3.1",
         "mime-types": "3.0.2",
         "minimatch": "10.0.3",
+        "node-edge-tts": "^1.2.10",
         "open": "10.1.2",
         "opencode-gitlab-auth": "2.0.0",
         "opencode-poe-auth": "0.0.1",
@@ -3723,6 +3724,8 @@
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
+    "node-edge-tts": ["node-edge-tts@1.2.10", "", { "dependencies": { "https-proxy-agent": "^7.0.1", "ws": "^8.13.0", "yargs": "^17.7.2" }, "bin": { "node-edge-tts": "bin.js" } }, "sha512-bV2i4XU54D45+US0Zm1HcJRkifuB3W438dWyuJEHLQdKxnuqlI1kim2MOvR6Q3XUQZvfF9PoDyR1Rt7aeXhPdQ=="],
+
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
@@ -3927,7 +3930,7 @@
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
-    "poe-oauth": ["poe-oauth@0.0.3", "", {}, "sha512-KgxDylcuq/mov8URSplrBGjrIjkQwjN/Ml8BhqaGsAvHzYN3yhuROdv1sDRfwqncg7TT8XzJvMeJAWmv/4NDLw=="],
+    "poe-oauth": ["poe-oauth@0.0.5", "", {}, "sha512-InvPkB/Hoe4hg2Hic2UhD6PiFjyxJojmQxkyPzybpyNh8SLGBLJDI/Df9FNJFzkGXgoVRSbchPoVS3SiWehDiw=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -5529,6 +5532,10 @@
 
     "nitro/h3": ["h3@2.0.1-rc.5", "", { "dependencies": { "rou3": "^0.7.9", "srvx": "^0.9.1" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"] }, "sha512-qkohAzCab0nLzXNm78tBjZDvtKMTmtygS8BJLT3VPczAQofdqlFXDPkXdLMJN4r05+xqneG8snZJ0HgkERCZTg=="],
 
+    "node-edge-tts/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
+    "node-edge-tts/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
     "node-gyp/nopt": ["nopt@8.1.0", "", { "dependencies": { "abbrev": "^3.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A=="],
 
     "node-gyp/which": ["which@5.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ=="],
@@ -6297,6 +6304,10 @@
 
     "motion/framer-motion/motion-dom": ["motion-dom@12.35.2", "", { "dependencies": { "motion-utils": "^12.29.2" } }, "sha512-pWXFMTwvGDbx1Fe9YL5HZebv2NhvGBzRtiNUv58aoK7+XrsuaydQ0JGRKK2r+bTKlwgSWwWxHbP5249Qr/BNpg=="],
 
+    "node-edge-tts/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "node-edge-tts/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "node-gyp/nopt/abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
 
     "node-gyp/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
@@ -6621,6 +6632,14 @@
 
     "js-beautify/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "node-edge-tts/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "node-edge-tts/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "node-edge-tts/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "node-edge-tts/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "opencode/@ai-sdk/openai-compatible/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "opencode/@ai-sdk/openai/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
@@ -6732,6 +6751,10 @@
     "js-beautify/glob/jackspeak/@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "js-beautify/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "node-edge-tts/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "node-edge-tts/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "opencontrol/@modelcontextprotocol/sdk/express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -25,6 +25,7 @@ import { useLanguage } from "@/context/language"
 import { useSessionKey } from "@/pages/session/session-layout"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { usePlatform } from "@/context/platform"
+import { useServer } from "@/context/server"
 import { useSettings } from "@/context/settings"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
@@ -239,6 +240,7 @@ export function MessageTimeline(props: {
   const settings = useSettings()
   const dialog = useDialog()
   const language = useLanguage()
+  const server = useServer()
   const { params, sessionKey } = useSessionKey()
   const platform = usePlatform()
 
@@ -291,13 +293,27 @@ export function MessageTimeline(props: {
     return "hidden"
   })
 
+  let audio: HTMLAudioElement | undefined
+  let audioUrl: string | undefined
+
+  const clearAudio = () => {
+    audio?.pause()
+    audio = undefined
+    if (!audioUrl) return
+    URL.revokeObjectURL(audioUrl)
+    audioUrl = undefined
+  }
+
+  onCleanup(() => {
+    clearAudio()
+  })
+
   createEffect(() => {
     if (workingStatus() !== "hiding") return
 
     setTimeoutDone(false)
     makeTimer(() => setTimeoutDone(true), 260, setTimeout)
   })
-
   const activeMessageID = createMemo(() => {
     const parentID = pending()?.parentID
     if (parentID) {
@@ -355,24 +371,49 @@ export function MessageTimeline(props: {
   let spokenMessage = ""
 
   const speak = (input: { messageID: string; text: string }) => {
-    const synth = typeof window === "undefined" ? undefined : getSpeechSynthesis<SpeechSynthLike>(window)
-    const Ctor =
-      typeof window === "undefined" ? undefined : getSpeechSynthesisUtteranceCtor<SpeechUtteranceLike>(window)
-    if (!synth || !Ctor) {
-      showToast({
-        title: language.t("prompt.toast.voicePlaybackUnavailable.title"),
-        description: language.t("prompt.toast.voicePlaybackUnavailable.description"),
+    spokenMessage = input.messageID
+    const conn = server.current?.http
+    const run = async () => {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      }
+      if (conn?.password) {
+        headers.Authorization = `Basic ${btoa(`${conn.username ?? "opencode"}:${conn.password}`)}`
+      }
+
+      const res = await (platform.fetch ?? fetch)(new URL("/tts/edge", conn?.url ?? globalSDK.url).toString(), {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ text: input.text }),
       })
-      return
+
+      if (!res.ok) throw new Error(`Edge TTS request failed (${res.status})`)
+      const blob = await res.blob()
+      clearAudio()
+      audioUrl = URL.createObjectURL(blob)
+      audio = new Audio(audioUrl)
+      await audio.play()
     }
 
-    spokenMessage = input.messageID
-    const utterance = new Ctor(input.text)
-    utterance.lang =
-      typeof document !== "undefined" ? document.documentElement.lang || navigator.language || "en-US" : "en-US"
-    utterance.rate = 1
-    synth.cancel()
-    synth.speak(utterance)
+    void run().catch(() => {
+      const synth = typeof window === "undefined" ? undefined : getSpeechSynthesis<SpeechSynthLike>(window)
+      const Ctor =
+        typeof window === "undefined" ? undefined : getSpeechSynthesisUtteranceCtor<SpeechUtteranceLike>(window)
+      if (!synth || !Ctor) {
+        showToast({
+          title: language.t("prompt.toast.voicePlaybackUnavailable.title"),
+          description: language.t("prompt.toast.voicePlaybackUnavailable.description"),
+        })
+        return
+      }
+
+      const utterance = new Ctor(input.text)
+      utterance.lang =
+        typeof document !== "undefined" ? document.documentElement.lang || navigator.language || "en-US" : "en-US"
+      utterance.rate = 1
+      synth.cancel()
+      synth.speak(utterance)
+    })
   }
 
   createEffect(() => {

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -136,6 +136,7 @@
     "jsonc-parser": "3.3.1",
     "mime-types": "3.0.2",
     "minimatch": "10.0.3",
+    "node-edge-tts": "^1.2.10",
     "open": "10.1.2",
     "opencode-gitlab-auth": "2.0.0",
     "opentui-spinner": "0.0.6",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1188,6 +1188,23 @@ export namespace Config {
       instructions: z.array(z.string()).optional().describe("Additional instruction files or patterns to include"),
       layout: Layout.optional().describe("@deprecated Always uses stretch layout."),
       permission: Permission.optional(),
+      voice: z
+        .object({
+          edge: z
+            .object({
+              enabled: z.boolean().optional().describe("Enable server-backed Edge TTS playback"),
+              voice: z.string().optional().describe("Edge neural voice name"),
+              lang: z.string().optional().describe("Edge TTS language code"),
+              output_format: z.string().optional().describe("Edge TTS output format"),
+              pitch: z.string().optional().describe("Edge TTS pitch percent string"),
+              rate: z.string().optional().describe("Edge TTS rate percent string"),
+              volume: z.string().optional().describe("Edge TTS volume percent string"),
+              timeout_ms: z.number().int().positive().optional().describe("Edge TTS timeout in milliseconds"),
+            })
+            .optional(),
+        })
+        .optional()
+        .describe("Voice playback configuration"),
       tools: z.record(z.string(), z.boolean()).optional(),
       enterprise: z
         .object({

--- a/packages/opencode/src/node-edge-tts.d.ts
+++ b/packages/opencode/src/node-edge-tts.d.ts
@@ -1,0 +1,18 @@
+declare module "node-edge-tts" {
+  export type EdgeTTSOptions = {
+    voice?: string
+    lang?: string
+    outputFormat?: string
+    saveSubtitles?: boolean
+    proxy?: string
+    rate?: string
+    pitch?: string
+    volume?: string
+    timeout?: number
+  }
+
+  export class EdgeTTS {
+    constructor(options?: EdgeTTSOptions)
+    ttsPromise(text: string, outputPath: string): Promise<void>
+  }
+}

--- a/packages/opencode/src/server/routes/tts.ts
+++ b/packages/opencode/src/server/routes/tts.ts
@@ -1,0 +1,44 @@
+import { Hono } from "hono"
+import { describeRoute, validator } from "hono-openapi"
+import z from "zod"
+import { lazy } from "@/util/lazy"
+import { synth } from "@/tts/edge"
+import { errors } from "../error"
+
+export const TtsRoutes = lazy(() =>
+  new Hono().post(
+    "/edge",
+    describeRoute({
+      summary: "Convert text to speech with Edge TTS",
+      description: "Generate MP3 audio using the server-backed Edge TTS engine.",
+      operationId: "tts.edge",
+      responses: {
+        200: {
+          description: "MP3 audio",
+          content: {
+            "audio/mpeg": {
+              schema: { type: "string", format: "binary" },
+            },
+          },
+        },
+        ...errors(400),
+      },
+    }),
+    validator(
+      "json",
+      z.object({
+        text: z.string().min(1).max(4096),
+      }),
+    ),
+    async (c) => {
+      const body = c.req.valid("json")
+      const audio = await synth(body.text.trim())
+      return new Response(audio, {
+        headers: {
+          "Content-Type": "audio/mpeg",
+          "Cache-Control": "no-store",
+        },
+      })
+    },
+  ),
+)

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -41,6 +41,7 @@ import { Filesystem } from "@/util/filesystem"
 import { QuestionRoutes } from "./routes/question"
 import { PermissionRoutes } from "./routes/permission"
 import { GlobalRoutes } from "./routes/global"
+import { TtsRoutes } from "./routes/tts"
 import { MDNS } from "./mdns"
 import { lazy } from "@/util/lazy"
 
@@ -143,6 +144,7 @@ export namespace Server {
         }),
       )
       .route("/global", GlobalRoutes())
+      .route("/tts", TtsRoutes())
       .put(
         "/auth/:providerID",
         describeRoute({
@@ -550,10 +552,7 @@ export namespace Server {
             host: "app.opencode.ai",
           },
         })
-        response.headers.set(
-          "Content-Security-Policy",
-          csp,
-        )
+        response.headers.set("Content-Security-Policy", csp)
         return response
       })
   }

--- a/packages/opencode/src/tts/edge.ts
+++ b/packages/opencode/src/tts/edge.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, stat, unlink } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { EdgeTTS } from "node-edge-tts"
+import { Config } from "@/config/config"
+
+const defaults = {
+  voice: "en-US-MichelleNeural",
+  lang: "en-US",
+  output_format: "audio-24khz-48kbitrate-mono-mp3",
+  timeout_ms: 30_000,
+}
+
+export async function synth(text: string) {
+  if (!text.trim()) throw new Error("Empty text")
+  // Use global config — TTS settings are not per-project and the
+  // /tts/edge route is mounted before the Instance middleware.
+  const cfg = await Config.getGlobal()
+  const edge = cfg.voice?.edge
+  // Only disable when explicitly set to false; undefined/missing = enabled
+  if (edge?.enabled === false) throw new Error("Edge TTS is disabled")
+
+  const dir = await mkdtemp(path.join(tmpdir(), "opencode-tts-"))
+  const file = path.join(dir, `voice-${Date.now()}.mp3`)
+  const tts = new EdgeTTS({
+    voice: edge?.voice ?? defaults.voice,
+    lang: edge?.lang ?? defaults.lang,
+    outputFormat: edge?.output_format ?? defaults.output_format,
+    rate: edge?.rate,
+    pitch: edge?.pitch,
+    volume: edge?.volume,
+    timeout: edge?.timeout_ms ?? defaults.timeout_ms,
+  })
+
+  await tts.ttsPromise(text, file)
+  const info = await stat(file)
+  if (!info.size) throw new Error("Edge TTS produced empty audio file")
+
+  const audio = await Bun.file(file).arrayBuffer()
+  await unlink(file).catch(() => {})
+  return new Uint8Array(audio)
+}

--- a/packages/opencode/test/tts/edge.test.ts
+++ b/packages/opencode/test/tts/edge.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import { synth } from "../../src/tts/edge"
+
+describe("tts.edge.synth", () => {
+  test("rejects empty text", async () => {
+    await expect(synth("")).rejects.toThrow("Empty text")
+    await expect(synth("   ")).rejects.toThrow("Empty text")
+  })
+
+  test(
+    "produces mp3 audio bytes",
+    async () => {
+      const audio = await synth("Hello, world")
+      expect(audio).toBeInstanceOf(Uint8Array)
+      expect(audio.length).toBeGreaterThan(100)
+      // MP3 files start with 0xFF 0xFB/0xF3 sync word or ID3 tag (0x49 0x44 0x33)
+      const isMP3 =
+        (audio[0] === 0xff && (audio[1] & 0xe0) === 0xe0) ||
+        (audio[0] === 0x49 && audio[1] === 0x44 && audio[2] === 0x33)
+      expect(isMP3).toBe(true)
+    },
+    { timeout: 30_000 },
+  )
+})

--- a/packages/opencode/test/tts/route.test.ts
+++ b/packages/opencode/test/tts/route.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+import { Server } from "../../src/server/server"
+import { Log } from "../../src/util/log"
+
+Log.init({ print: false })
+
+describe("server tts route", () => {
+  test("returns 400 for missing text", async () => {
+    const app = Server.createApp({})
+    const res = await app.request("/tts/edge", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  test("returns 400 for empty text", async () => {
+    const app = Server.createApp({})
+    const res = await app.request("/tts/edge", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "" }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  test(
+    "returns audio/mpeg for valid text",
+    async () => {
+      const app = Server.createApp({})
+      const res = await app.request("/tts/edge", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "Test speech" }),
+      })
+      expect(res.status).toBe(200)
+      expect(res.headers.get("content-type")).toBe("audio/mpeg")
+      expect(res.headers.get("cache-control")).toBe("no-store")
+      const buf = await res.arrayBuffer()
+      expect(buf.byteLength).toBeGreaterThan(100)
+    },
+    { timeout: 30_000 },
+  )
+})


### PR DESCRIPTION
## Summary

This finishes the remaining code-side local branch consolidation against `main`.

After auditing local branches against `origin/main`, the only unreconciled code change still missing from `main` was the Edge TTS feature branch.

This PR merges that remaining delta:
- server-backed Edge TTS output route and implementation
- app wiring for spoken assistant replies via Edge TTS
- focused TTS tests

The other local feature/fix branches that looked suspicious during audit were checked and found to already be represented on `main` under earlier commits or squashed integration commits, including:
- per-message speaker icon
- browser mic preflight
- session tree / recent-session archive stabilization
- rename tool
- scoped publish / desktop mic permission support
- cross-spawn process handling fix
- bash output spooling fix

Refs #36

## Verification

- `cd packages/opencode && bun test test/tts/edge.test.ts test/tts/route.test.ts`
- `cd packages/opencode && bun typecheck`
- `cd packages/app && bun typecheck`
