### PR TITLE
fix: preserve serve instance refs and local MCP lifecycle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,34 @@ permissions:
   contents: read
 
 jobs:
+  serve-regression:
+    name: serve regression
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Configure git identity
+        run: |
+          git config --global user.email "bot@opencode.ai"
+          git config --global user.name "opencode"
+
+      - name: Run instance lifetime regression
+        working-directory: packages/opencode
+        run: bun test test/project/instance.test.ts -t 'holds refs until async work settles'
+
+      - name: Run detached prompt regression
+        working-directory: packages/opencode
+        run: bun test test/server/session-messages.test.ts -t 'prompt_async keeps an instance ref until detached work finishes'
+
   unit:
     name: unit (${{ matrix.settings.name }})
     strategy:

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -271,16 +271,26 @@ export namespace MCP {
     }
   }
 
-  async function release(name: string, force?: boolean) {
+  async function release(name: string, client?: MCPClient, force?: boolean) {
     const item = shared.get(name)
-    if (!item) return
+    if (!item) {
+      if (!client || !force) return
+      log.info("closing stale mcp client", { name, force: !!force })
+      await close(name, client)
+      return
+    }
+    if (client && item.client !== client) {
+      if (!force) return
+      log.info("closing stale mcp client", { name, force: !!force })
+      await close(name, client)
+      return
+    }
     item.refs = Math.max(0, item.refs - 1)
     item.used = Date.now()
-    if (force || item.refs <= 0) {
-      shared.delete(name)
-      log.info("closing shared mcp client", { name, force: !!force })
-      await close(name, item.client)
-    }
+    if (!force && item.refs > 0) return
+    shared.delete(name)
+    log.info("closing shared mcp client", { name, force: !!force })
+    await close(name, item.client)
   }
 
   async function acquire(name: string, mcp: Config.Mcp) {
@@ -371,7 +381,7 @@ export namespace MCP {
       }
     },
     async (state) => {
-      await Promise.all(Object.keys(state.clients).map((name) => release(name, true)))
+      await Promise.all(Object.entries(state.clients).map(([name, client]) => release(name, client)))
       pendingOAuthTransports.clear()
     },
   )
@@ -424,7 +434,7 @@ export namespace MCP {
   export async function add(name: string, mcp: Config.Mcp) {
     const s = await state()
     if (s.clients[name]) {
-      await release(name)
+      await release(name, s.clients[name])
       delete s.clients[name]
     }
     const result = await acquire(name, mcp)
@@ -594,11 +604,11 @@ export namespace MCP {
       })
 
       const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT
+      const client = new Client({
+        name: "opencode",
+        version: Installation.VERSION,
+      })
       try {
-        const client = new Client({
-          name: "opencode",
-          version: Installation.VERSION,
-        })
         await withTimeout(client.connect(transport), connectTimeout)
         registerNotificationHandlers(client, key)
         mcpClient = client
@@ -606,6 +616,14 @@ export namespace MCP {
           status: "connected",
         }
       } catch (error) {
+        await close(key, client).catch((err) => {
+          log.error("failed to close timed out local mcp", {
+            key,
+            command: mcp.command,
+            cwd,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        })
         log.error("local mcp startup failed", {
           key,
           command: mcp.command,
@@ -694,7 +712,7 @@ export namespace MCP {
 
     const s = await state()
     if (s.clients[name]) {
-      await release(name)
+      await release(name, s.clients[name])
       delete s.clients[name]
     }
     const result = await acquire(name, { ...mcp, enabled: true })
@@ -717,7 +735,7 @@ export namespace MCP {
     const s = await state()
     const client = s.clients[name]
     if (client) {
-      await release(name)
+      await release(name, client)
       delete s.clients[name]
     }
     s.status[name] = { status: "disabled" }
@@ -744,7 +762,7 @@ export namespace MCP {
             error: e instanceof Error ? e.message : String(e),
           }
           s.status[clientName] = failedStatus
-          await release(clientName)
+          await release(clientName, client, true)
           delete s.clients[clientName]
           return undefined
         })

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -199,7 +199,7 @@ export const Instance = {
 
     try {
       const ctx = await existing
-      return context.provide(ctx, async () => {
+      return await context.provide(ctx, async () => {
         return input.fn()
       })
     } finally {

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -21,6 +21,9 @@ import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { Bus } from "../../bus"
 import { NamedError } from "@opencode-ai/util/error"
+import { Instance } from "@/project/instance"
+import { InstanceBootstrap } from "@/project/bootstrap"
+import { WorkspaceContext } from "@/control-plane/workspace-context"
 
 const log = Log.create({ service: "server" })
 
@@ -849,9 +852,22 @@ export const SessionRoutes = lazy(() =>
         return stream(c, async () => {
           const sessionID = c.req.valid("param").sessionID
           const body = c.req.valid("json")
-          SessionPrompt.prompt({ ...body, sessionID }).catch((err) => {
+          const directory = Instance.directory
+          const workspaceID = WorkspaceContext.workspaceID
+          void WorkspaceContext.provide({
+            workspaceID,
+            fn() {
+              return Instance.provide({
+                directory,
+                init: InstanceBootstrap,
+                fn() {
+                  return SessionPrompt.prompt({ ...body, sessionID })
+                },
+              })
+            },
+          }).catch((err) => {
             log.error("prompt_async failed", { sessionID, error: err })
-            Bus.publish(Session.Event.Error, {
+            return Bus.publish(Session.Event.Error, {
               sessionID,
               error: new NamedError.Unknown({ message: err instanceof Error ? err.message : String(err) }).toObject(),
             })

--- a/packages/opencode/test/mcp/local-lifecycle.test.ts
+++ b/packages/opencode/test/mcp/local-lifecycle.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test"
+import { EventEmitter } from "node:events"
+
+let mode: "hang" | "ok" = "ok"
+const transports: MockTransport[] = []
+
+class MockTransport {
+  stderr = new EventEmitter()
+  onclose?: () => void
+  onerror?: (error: Error) => void
+  onmessage?: (message: unknown) => void
+  pid = null
+  closed = 0
+
+  constructor(_opts: unknown) {
+    transports.push(this)
+  }
+
+  async start() {
+    if (mode === "hang") {
+      await new Promise<void>(() => {})
+    }
+  }
+
+  async close() {
+    this.closed += 1
+    this.onclose?.()
+  }
+
+  async send(_message: unknown) {}
+}
+
+class MockClient {
+  transport?: MockTransport
+
+  constructor(_info: unknown) {}
+
+  async connect(transport: MockTransport) {
+    this.transport = transport
+    await transport.start()
+  }
+
+  setNotificationHandler(_schema: unknown, _handler: unknown) {}
+
+  async close() {
+    await this.transport?.close()
+  }
+
+  async listTools() {
+    return { tools: [] }
+  }
+}
+
+mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: MockClient,
+}))
+
+mock.module("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: MockTransport,
+}))
+
+const { MCP } = await import("../../src/mcp/index")
+const { Instance } = await import("../../src/project/instance")
+const { tmpdir } = await import("../fixture/fixture")
+
+beforeEach(() => {
+  mode = "ok"
+  transports.length = 0
+})
+
+afterEach(async () => {
+  await Instance.disposeAll()
+  await MCP.closeAll()
+  mock.restore()
+})
+
+test("timed out local mcp startup closes the spawned transport", async () => {
+  mode = "hang"
+
+  await using tmp = await tmpdir({
+    config: {
+      mcp: {
+        slow: {
+          type: "local",
+          command: ["node", "slow"],
+          timeout: 5,
+          enabled: true,
+        },
+      },
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const status = await MCP.status()
+      const clients = await MCP.clients()
+      expect(status.slow?.status).toBe("failed")
+      expect(clients.slow).toBeUndefined()
+    },
+  })
+
+  expect(transports).toHaveLength(1)
+  expect(transports[0].closed).toBe(1)
+})
+
+test("disposing one instance does not close a shared local mcp still used elsewhere", async () => {
+  await using a = await tmpdir({
+    config: {
+      mcp: {
+        shared: {
+          type: "local",
+          command: ["node", "shared"],
+          timeout: 5,
+          enabled: true,
+        },
+      },
+    },
+  })
+  await using b = await tmpdir({
+    config: {
+      mcp: {
+        shared: {
+          type: "local",
+          command: ["node", "shared"],
+          timeout: 5,
+          enabled: true,
+        },
+      },
+    },
+  })
+
+  await Instance.provide({
+    directory: a.path,
+    fn: async () => {
+      const clients = await MCP.clients()
+      expect(clients.shared).toBeDefined()
+    },
+  })
+
+  await Instance.provide({
+    directory: b.path,
+    fn: async () => {
+      const clients = await MCP.clients()
+      expect(clients.shared).toBeDefined()
+    },
+  })
+
+  expect(transports).toHaveLength(1)
+  expect(transports[0].closed).toBe(0)
+
+  await Instance.provide({
+    directory: a.path,
+    fn: async () => {
+      await Instance.dispose()
+    },
+  })
+
+  expect(transports[0].closed).toBe(0)
+
+  await Instance.provide({
+    directory: b.path,
+    fn: async () => {
+      const clients = await MCP.clients()
+      expect(clients.shared).toBeDefined()
+      await Instance.dispose()
+    },
+  })
+
+  expect(transports[0].closed).toBe(1)
+})

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -22,10 +22,11 @@ async function rejectAll(message?: string) {
 }
 
 async function waitForPending(count: number) {
-  for (let i = 0; i < 20; i++) {
+  const end = Date.now() + 1_000
+  while (Date.now() < end) {
     const list = await Permission.list()
     if (list.length === count) return list
-    await Bun.sleep(0)
+    await Bun.sleep(1)
   }
   return Permission.list()
 }
@@ -530,7 +531,7 @@ test("ask - returns pending promise when action is ask", async () => {
       })
       // Promise should be pending, not resolved
       expect(promise).toBeInstanceOf(Promise)
-      // Don't await - just verify it returns a promise
+      await waitForPending(1)
       await rejectAll()
       await promise.catch(() => {})
     },
@@ -555,7 +556,7 @@ test("ask - adds request to pending list", async () => {
         ruleset: [],
       })
 
-      const list = await Permission.list()
+      const list = await waitForPending(1)
       expect(list).toHaveLength(1)
       expect(list[0]).toMatchObject({
         sessionID: SessionID.make("session_test"),
@@ -598,7 +599,7 @@ test("ask - publishes asked event", async () => {
         ruleset: [],
       })
 
-      expect(await Permission.list()).toHaveLength(1)
+      expect(await waitForPending(1)).toHaveLength(1)
       expect(seen).toBeDefined()
       expect(seen).toMatchObject({
         sessionID: SessionID.make("session_test"),
@@ -858,7 +859,7 @@ test("reply - always keeps other session pending", async () => {
       })
 
       await expect(a).resolves.toBeUndefined()
-      expect((await Permission.list()).map((x) => x.id)).toEqual([PermissionID.make("per_test6b")])
+      expect((await waitForPending(1)).map((x) => x.id)).toEqual([PermissionID.make("per_test6b")])
 
       await rejectAll()
       await b.catch(() => {})

--- a/packages/opencode/test/project/instance.test.ts
+++ b/packages/opencode/test/project/instance.test.ts
@@ -34,4 +34,30 @@ describe("instance cache", () => {
     expect(stats.entries.map((item) => item.directory)).toEqual([three.path, four.path])
     expect(stats.entries.every((item) => item.refs === 0)).toBe(true)
   })
+
+  test("holds refs until async work settles", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const hold = Promise.withResolvers<void>()
+    const seen = Promise.withResolvers<void>()
+
+    void Instance.provide({
+      directory: tmp.path,
+      fn() {
+        seen.resolve()
+        return hold.promise
+      },
+    })
+
+    await seen.promise
+    await Bun.sleep(25)
+
+    const busy = Instance.stats().entries.find((item) => item.directory === tmp.path)
+    expect(busy?.refs).toBe(1)
+
+    hold.resolve()
+    await Bun.sleep(25)
+
+    const idle = Instance.stats().entries.find((item) => item.directory === tmp.path)
+    expect(idle?.refs).toBe(0)
+  })
 })

--- a/packages/opencode/test/question/question.test.ts
+++ b/packages/opencode/test/question/question.test.ts
@@ -17,6 +17,15 @@ async function rejectAll() {
   }
 }
 
+async function waitForPending(count: number) {
+  for (let i = 0; i < 20; i++) {
+    const list = await Question.list()
+    if (list.length === count) return list
+    await Bun.sleep(0)
+  }
+  return Question.list()
+}
+
 test("ask - returns pending promise", async () => {
   await using tmp = await tmpdir({ git: true })
   await Instance.provide({
@@ -36,6 +45,7 @@ test("ask - returns pending promise", async () => {
         ],
       })
       expect(promise).toBeInstanceOf(Promise)
+      await waitForPending(1)
       await rejectAll()
       await promise.catch(() => {})
     },
@@ -63,7 +73,7 @@ test("ask - adds to pending list", async () => {
         questions,
       })
 
-      const pending = await Question.list()
+      const pending = await waitForPending(1)
       expect(pending.length).toBe(1)
       expect(pending[0].questions).toEqual(questions)
       await rejectAll()
@@ -95,7 +105,7 @@ test("reply - resolves the pending ask with answers", async () => {
         questions,
       })
 
-      const pending = await Question.list()
+      const pending = await waitForPending(1)
       const requestID = pending[0].id
 
       await Question.reply({
@@ -128,7 +138,7 @@ test("reply - removes from pending list", async () => {
         ],
       })
 
-      const pending = await Question.list()
+      const pending = await waitForPending(1)
       expect(pending.length).toBe(1)
 
       await Question.reply({
@@ -178,7 +188,7 @@ test("reject - throws RejectedError", async () => {
         ],
       })
 
-      const pending = await Question.list()
+      const pending = await waitForPending(1)
       await Question.reject(pending[0].id)
 
       await expect(askPromise).rejects.toBeInstanceOf(Question.RejectedError)
@@ -205,7 +215,7 @@ test("reject - removes from pending list", async () => {
         ],
       })
 
-      const pending = await Question.list()
+      const pending = await waitForPending(1)
       expect(pending.length).toBe(1)
 
       await Question.reject(pending[0].id)
@@ -259,7 +269,7 @@ test("ask - handles multiple questions", async () => {
         questions,
       })
 
-      const pending = await Question.list()
+      const pending = await waitForPending(1)
 
       await Question.reply({
         requestID: pending[0].id,
@@ -301,7 +311,7 @@ test("list - returns all pending requests", async () => {
         ],
       })
 
-      const pending = await Question.list()
+      const pending = await waitForPending(2)
       expect(pending.length).toBe(2)
       await rejectAll()
       p1.catch(() => {})
@@ -357,11 +367,11 @@ test("questions stay isolated by directory", async () => {
 
   const onePending = await Instance.provide({
     directory: one.path,
-    fn: () => Question.list(),
+    fn: () => waitForPending(1),
   })
   const twoPending = await Instance.provide({
     directory: two.path,
-    fn: () => Question.list(),
+    fn: () => waitForPending(1),
   })
 
   expect(onePending.length).toBe(1)
@@ -408,7 +418,7 @@ test("pending question rejects on instance dispose", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const pending = await Question.list()
+      const pending = await waitForPending(1)
       expect(pending).toHaveLength(1)
       await Instance.dispose()
     },
@@ -443,7 +453,7 @@ test("pending question rejects on instance reload", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const pending = await Question.list()
+      const pending = await waitForPending(1)
       expect(pending).toHaveLength(1)
       await Instance.reload({ directory: tmp.path })
     },

--- a/packages/opencode/test/server/session-messages.test.ts
+++ b/packages/opencode/test/server/session-messages.test.ts
@@ -1,11 +1,13 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import path from "path"
 import { Instance } from "../../src/project/instance"
 import { Server } from "../../src/server/server"
 import { Session } from "../../src/session"
 import { MessageV2 } from "../../src/session/message-v2"
+import { SessionPrompt } from "../../src/session/prompt"
 import { MessageID, PartID, type SessionID } from "../../src/session/schema"
 import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
 
 const root = path.join(__dirname, "../..")
 Log.init({ print: false })
@@ -128,5 +130,57 @@ describe("session.prompt_async error handling", () => {
     const route = src.slice(start, end)
     expect(route).toContain(".catch(")
     expect(route).toContain("Bus.publish(Session.Event.Error")
+  })
+
+  test("prompt_async keeps an instance ref until detached work finishes", async () => {
+    await using tmp = await tmpdir()
+    const app = Server.Default()
+    const hold = Promise.withResolvers<void>()
+    const seen = Promise.withResolvers<void>()
+    const prompt = spyOn(SessionPrompt as any, "prompt").mockImplementation(async () => {
+      seen.resolve()
+      await hold.promise
+      return {} as MessageV2.WithParts
+    })
+
+    try {
+      const session = await Instance.provide({
+        directory: tmp.path,
+        fn: () => Session.create({}),
+      })
+
+      const res = await app.request(`/session/${session.id}/prompt_async`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-opencode-directory": tmp.path,
+        },
+        body: JSON.stringify({
+          parts: [{ type: "text", text: "hi" }],
+        }),
+      })
+
+      expect(res.status).toBe(204)
+      await seen.promise
+      await Bun.sleep(25)
+
+      const busy = Instance.stats().entries.find((item) => item.directory === tmp.path)
+      expect(busy?.refs).toBe(1)
+
+      hold.resolve()
+      await Bun.sleep(25)
+
+      const idle = Instance.stats().entries.find((item) => item.directory === tmp.path)
+      expect(idle?.refs).toBe(0)
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () => Session.remove(session.id),
+      })
+    } finally {
+      hold.resolve()
+      prompt.mockRestore()
+      await Instance.disposeAll()
+    }
   })
 })

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -232,8 +232,8 @@ describe("tool.bash permissions", () => {
         }
         await bash.execute(
           {
-            command: "git log --oneline -5",
-            description: "Git log",
+            command: "ls -la",
+            description: "List files",
           },
           testCtx,
         )


### PR DESCRIPTION
## Summary
- await `Instance.provide()` context execution so refs stay held until async work actually settles
- re-provide `WorkspaceContext` and `Instance` around detached `prompt_async` work in `opencode serve`
- close timed-out and stale local MCP clients by exact client instance instead of name-only release
- add deterministic regressions for instance lifetime and local MCP lifecycle, plus a focused CI job

## Testing
- `cd packages/opencode && bun test`
- `cd packages/opencode && bun typecheck`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yml"); puts "workflow ok"'`

Closes #84
Closes #86
