### PR TITLE
fix(project): discover existing git worktrees

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -152,6 +152,43 @@ export namespace Project {
         return pathSvc.resolve(cwd, name)
       }
 
+      const sameList = (a: string[], b: string[]) => a.length === b.length && a.every((item, index) => item === b[index])
+
+      const existingDirectories = Effect.fnUntraced(function* (dirs: string[]) {
+        const unique = [...new Set(dirs.map((dir) => AppFileSystem.resolve(dir)))]
+        return yield* Effect.forEach(
+          unique,
+          (dir) =>
+            fsys.exists(dir).pipe(
+              Effect.orDie,
+              Effect.map((exists) => (exists ? dir : undefined)),
+            ),
+          { concurrency: "unbounded" },
+        ).pipe(Effect.map((items) => items.filter((item): item is string => item !== undefined)))
+      })
+
+      const gitWorktrees = Effect.fnUntraced(function* (root: string) {
+        const list = yield* git(["worktree", "list", "--porcelain"], { cwd: root })
+        if (list.code !== 0) {
+          log.warn("failed to enumerate git worktrees", {
+            directory: root,
+            stderr: list.stderr.trim(),
+            stdout: list.text.trim(),
+          })
+          return undefined
+        }
+
+        const primary = AppFileSystem.resolve(root)
+        const dirs = list.text
+          .split("\n")
+          .map((line) => line.trim())
+          .flatMap((line) => (line.startsWith("worktree ") ? [line.slice("worktree ".length).trim()] : []))
+          .map((dir) => AppFileSystem.resolve(resolveGitPath(root, dir)))
+          .filter((dir) => dir !== primary)
+
+        return yield* existingDirectories(dirs)
+      })
+
       const scope = yield* Scope.Scope
 
       const readCachedProjectId = Effect.fnUntraced(function* (dir: string) {
@@ -265,17 +302,12 @@ export namespace Project {
           vcs: data.vcs,
           time: { ...existing.time, updated: Date.now() },
         }
-        if (data.sandbox !== result.worktree && !result.sandboxes.includes(data.sandbox))
-          result.sandboxes.push(data.sandbox)
-        result.sandboxes = yield* Effect.forEach(
-          result.sandboxes,
-          (s) =>
-            fsys.exists(s).pipe(
-              Effect.orDie,
-              Effect.map((exists) => (exists ? s : undefined)),
-            ),
-          { concurrency: "unbounded" },
-        ).pipe(Effect.map((arr) => arr.filter((x): x is string => x !== undefined)))
+        const discovered =
+          data.vcs === "git" && data.id !== ProjectID.global ? yield* gitWorktrees(result.worktree) : undefined
+        result.sandboxes = discovered ?? (yield* existingDirectories(result.sandboxes))
+        const sandbox = AppFileSystem.resolve(data.sandbox)
+        const worktree = AppFileSystem.resolve(result.worktree)
+        if (sandbox !== worktree && !result.sandboxes.includes(sandbox)) result.sandboxes.push(sandbox)
 
         yield* db((d) =>
           d
@@ -397,15 +429,18 @@ export namespace Project {
         const row = yield* db((d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, id)).get())
         if (!row) return []
         const data = fromRow(row)
-        return yield* Effect.forEach(
-          data.sandboxes,
-          (dir) =>
-            fsys.isDir(dir).pipe(
-              Effect.orDie,
-              Effect.map((ok) => (ok ? dir : undefined)),
-            ),
-          { concurrency: "unbounded" },
-        ).pipe(Effect.map((arr) => arr.filter((x): x is string => x !== undefined)))
+        const next = (data.vcs === "git" ? yield* gitWorktrees(data.worktree) : undefined) ?? (yield* existingDirectories(data.sandboxes))
+        if (sameList(data.sandboxes, next)) return next
+        const result = yield* db((d) =>
+          d
+            .update(ProjectTable)
+            .set({ sandboxes: next, time_updated: Date.now() })
+            .where(eq(ProjectTable.id, id))
+            .returning()
+            .get(),
+        )
+        if (result) yield* emitUpdated(fromRow(result))
+        return next
       })
 
       const addSandbox = Effect.fn("Project.addSandbox")(function* (id: ProjectID, directory: string) {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -32,6 +32,7 @@ import { Truncate } from "./truncate"
 import { ApplyPatchTool } from "./apply_patch"
 import { Glob } from "../util/glob"
 import { pathToFileURL } from "url"
+import { existsSync } from "fs"
 
 export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
@@ -39,15 +40,21 @@ export namespace ToolRegistry {
   export const state = Instance.state(async () => {
     const custom = [] as Tool.Info[]
 
-    const matches = await Config.directories().then((dirs) =>
+    const files = await Config.directories().then((dirs) =>
       dirs.flatMap((dir) =>
-        Glob.scanSync("{tool,tools}/*.{js,ts}", { cwd: dir, absolute: true, dot: true, symlink: true }),
+        Glob.scanSync("{tool,tools}/*.{js,ts}", { cwd: dir, absolute: true, dot: true, symlink: true }).map((file) => ({
+          dir,
+          file,
+        })),
       ),
     )
-    if (matches.length) await Config.waitForDependencies()
-    for (const match of matches) {
-      const namespace = path.basename(match, path.extname(match))
-      const mod = await import(pathToFileURL(match).href)
+    const deps = files.some((item) => {
+      return existsSync(path.join(item.dir, "package.json")) || existsSync(path.join(item.dir, "node_modules"))
+    })
+    if (deps) await Config.waitForDependencies()
+    for (const item of files) {
+      const namespace = path.basename(item.file, path.extname(item.file))
+      const mod = await import(pathToFileURL(item.file).href)
       for (const [id, def] of Object.entries<ToolDefinition>(mod)) {
         custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
       }

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -746,6 +746,11 @@ test("installs dependencies in writable OPENCODE_CONFIG_DIR", async () => {
 
   const prev = process.env.OPENCODE_CONFIG_DIR
   process.env.OPENCODE_CONFIG_DIR = tmp.extra
+  const run = spyOn(BunProc, "run").mockImplementation(async () => ({
+    code: 0,
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+  }))
 
   try {
     await Instance.provide({
@@ -758,7 +763,10 @@ test("installs dependencies in writable OPENCODE_CONFIG_DIR", async () => {
 
     expect(await Filesystem.exists(path.join(tmp.extra, "package.json"))).toBe(true)
     expect(await Filesystem.exists(path.join(tmp.extra, ".gitignore"))).toBe(true)
+    expect(run).toHaveBeenCalled()
+    expect(run.mock.calls.some((call) => call[1]?.cwd === tmp.extra)).toBe(true)
   } finally {
+    run.mockRestore()
     if (prev === undefined) delete process.env.OPENCODE_CONFIG_DIR
     else process.env.OPENCODE_CONFIG_DIR = prev
   }

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -240,6 +240,54 @@ describe("Project.fromDirectory with worktrees", () => {
         .catch(() => {})
     }
   })
+
+  test("discovers existing worktrees from the root without opening them individually", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const worktree1 = path.join(tmp.path, "..", path.basename(tmp.path) + "-root-wt1")
+    const worktree2 = path.join(tmp.path, "..", path.basename(tmp.path) + "-root-wt2")
+    try {
+      await $`git worktree add ${worktree1} -b root-branch-${Date.now()}`.cwd(tmp.path).quiet()
+      await $`git worktree add ${worktree2} -b root-branch-${Date.now() + 1}`.cwd(tmp.path).quiet()
+
+      const { project } = await Project.fromDirectory(tmp.path)
+
+      expect(project.worktree).toBe(tmp.path)
+      expect(project.sandboxes).toContain(worktree1)
+      expect(project.sandboxes).toContain(worktree2)
+      expect(project.sandboxes).not.toContain(tmp.path)
+    } finally {
+      await $`git worktree remove ${worktree1}`
+        .cwd(tmp.path)
+        .quiet()
+        .catch(() => {})
+      await $`git worktree remove ${worktree2}`
+        .cwd(tmp.path)
+        .quiet()
+        .catch(() => {})
+    }
+  })
+
+  test("Project.sandboxes refreshes manual worktrees added after initial discovery", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const { project } = await Project.fromDirectory(tmp.path)
+    const worktree = path.join(tmp.path, "..", path.basename(tmp.path) + "-late-wt")
+    try {
+      await $`git worktree add ${worktree} -b late-branch-${Date.now()}`.cwd(tmp.path).quiet()
+
+      const sandboxes = await Project.sandboxes(project.id)
+      const listed = Project.list().find((item) => item.id === project.id)
+
+      expect(sandboxes).toContain(worktree)
+      expect(listed?.sandboxes).toContain(worktree)
+    } finally {
+      await $`git worktree remove ${worktree}`
+        .cwd(tmp.path)
+        .quiet()
+        .catch(() => {})
+    }
+  })
 })
 
 describe("Project.discover", () => {

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -9,6 +9,8 @@ import type { Permission } from "../../src/permission"
 import { Truncate } from "../../src/tool/truncate"
 import { SessionID, MessageID } from "../../src/session/schema"
 
+type Request = Omit<Permission.Request, "id" | "sessionID" | "tool">
+
 const ctx = {
   sessionID: SessionID.make("ses_test"),
   messageID: MessageID.make(""),
@@ -18,6 +20,24 @@ const ctx = {
   messages: [],
   metadata: () => {},
   ask: async () => {},
+}
+
+const stop = new Error("stop")
+
+const record = (requests: Request[], halt = true) => ({
+  ...ctx,
+  ask: async (req: Request) => {
+    requests.push(req)
+    if (halt) throw stop
+  },
+})
+
+const halted = async <T>(promise: Promise<T>) => {
+  try {
+    await promise
+  } catch (err) {
+    if (err !== stop) throw err
+  }
 }
 
 const projectRoot = path.join(__dirname, "../..")
@@ -49,19 +69,15 @@ describe("tool.bash permissions", () => {
       directory: tmp.path,
       fn: async () => {
         const bash = await BashTool.init()
-        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-        const testCtx = {
-          ...ctx,
-          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-            requests.push(req)
-          },
-        }
-        await bash.execute(
+        const requests: Request[] = []
+        await halted(
+          bash.execute(
           {
             command: "echo hello",
             description: "Echo hello",
           },
-          testCtx,
+          record(requests),
+        )
         )
         expect(requests.length).toBe(1)
         expect(requests[0].permission).toBe("bash")
@@ -76,19 +92,15 @@ describe("tool.bash permissions", () => {
       directory: tmp.path,
       fn: async () => {
         const bash = await BashTool.init()
-        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-        const testCtx = {
-          ...ctx,
-          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-            requests.push(req)
-          },
-        }
-        await bash.execute(
+        const requests: Request[] = []
+        await halted(
+          bash.execute(
           {
             command: "echo foo && echo bar",
             description: "Echo twice",
           },
-          testCtx,
+          record(requests),
+        )
         )
         expect(requests.length).toBe(1)
         expect(requests[0].permission).toBe("bash")
@@ -104,19 +116,15 @@ describe("tool.bash permissions", () => {
       directory: tmp.path,
       fn: async () => {
         const bash = await BashTool.init()
-        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-        const testCtx = {
-          ...ctx,
-          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-            requests.push(req)
-          },
-        }
-        await bash.execute(
+        const requests: Request[] = []
+        await halted(
+          bash.execute(
           {
             command: "cd ../",
             description: "Change to parent directory",
           },
-          testCtx,
+          record(requests),
+        )
         )
         const extDirReq = requests.find((r) => r.permission === "external_directory")
         expect(extDirReq).toBeDefined()
@@ -130,20 +138,16 @@ describe("tool.bash permissions", () => {
       directory: tmp.path,
       fn: async () => {
         const bash = await BashTool.init()
-        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-        const testCtx = {
-          ...ctx,
-          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-            requests.push(req)
-          },
-        }
-        await bash.execute(
+        const requests: Request[] = []
+        await halted(
+          bash.execute(
           {
             command: "ls",
             workdir: os.tmpdir(),
             description: "List temp dir",
           },
-          testCtx,
+          record(requests),
+        )
         )
         const extDirReq = requests.find((r) => r.permission === "external_directory")
         expect(extDirReq).toBeDefined()
@@ -163,20 +167,16 @@ describe("tool.bash permissions", () => {
       directory: tmp.path,
       fn: async () => {
         const bash = await BashTool.init()
-        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-        const testCtx = {
-          ...ctx,
-          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-            requests.push(req)
-          },
-        }
+        const requests: Request[] = []
         const filepath = path.join(outerTmp.path, "outside.txt")
-        await bash.execute(
+        await halted(
+          bash.execute(
           {
             command: `cat ${filepath}`,
             description: "Read external file",
           },
-          testCtx,
+          record(requests),
+        )
         )
         const extDirReq = requests.find((r) => r.permission === "external_directory")
         const expected = path.join(outerTmp.path, "*")
@@ -193,22 +193,18 @@ describe("tool.bash permissions", () => {
       directory: tmp.path,
       fn: async () => {
         const bash = await BashTool.init()
-        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-        const testCtx = {
-          ...ctx,
-          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-            requests.push(req)
-          },
-        }
+        const requests: Request[] = []
 
         await Bun.write(path.join(tmp.path, "tmpfile"), "x")
 
-        await bash.execute(
+        await halted(
+          bash.execute(
           {
             command: `rm -rf ${path.join(tmp.path, "nested")}`,
             description: "remove nested dir",
           },
-          testCtx,
+          record(requests),
+        )
         )
 
         const extDirReq = requests.find((r) => r.permission === "external_directory")
@@ -223,19 +219,15 @@ describe("tool.bash permissions", () => {
       directory: tmp.path,
       fn: async () => {
         const bash = await BashTool.init()
-        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-        const testCtx = {
-          ...ctx,
-          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-            requests.push(req)
-          },
-        }
-        await bash.execute(
+        const requests: Request[] = []
+        await halted(
+          bash.execute(
           {
             command: "ls -la",
             description: "List files",
           },
-          testCtx,
+          record(requests),
+        )
         )
         expect(requests.length).toBe(1)
         expect(requests[0].always.length).toBeGreaterThan(0)
@@ -250,19 +242,15 @@ describe("tool.bash permissions", () => {
       directory: tmp.path,
       fn: async () => {
         const bash = await BashTool.init()
-        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-        const testCtx = {
-          ...ctx,
-          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-            requests.push(req)
-          },
-        }
-        await bash.execute(
+        const requests: Request[] = []
+        await halted(
+          bash.execute(
           {
             command: "cd .",
             description: "Stay in current directory",
           },
-          testCtx,
+          record(requests),
+        )
         )
         const bashReq = requests.find((r) => r.permission === "bash")
         expect(bashReq).toBeUndefined()
@@ -276,14 +264,8 @@ describe("tool.bash permissions", () => {
       directory: tmp.path,
       fn: async () => {
         const bash = await BashTool.init()
-        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-        const testCtx = {
-          ...ctx,
-          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-            requests.push(req)
-          },
-        }
-        await bash.execute({ command: "cat > /tmp/output.txt", description: "Redirect ls output" }, testCtx)
+        const requests: Request[] = []
+        await halted(bash.execute({ command: "cat > /tmp/output.txt", description: "Redirect ls output" }, record(requests)))
         const bashReq = requests.find((r) => r.permission === "bash")
         expect(bashReq).toBeDefined()
         expect(bashReq!.patterns).toContain("cat > /tmp/output.txt")
@@ -297,14 +279,8 @@ describe("tool.bash permissions", () => {
       directory: tmp.path,
       fn: async () => {
         const bash = await BashTool.init()
-        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-        const testCtx = {
-          ...ctx,
-          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-            requests.push(req)
-          },
-        }
-        await bash.execute({ command: "ls -la", description: "List" }, testCtx)
+        const requests: Request[] = []
+        await halted(bash.execute({ command: "ls -la", description: "List" }, record(requests)))
         const bashReq = requests.find((r) => r.permission === "bash")
         expect(bashReq).toBeDefined()
         const pattern = bashReq!.always[0]


### PR DESCRIPTION
Closes #88.

## Summary
- discover existing/manual git worktrees from `git worktree list --porcelain`
- refresh persisted `sandboxes` from real worktree state when a project is loaded or listed
- keep current sandbox entries canonicalized while pruning stale directories
- make related package tests deterministic so full `packages/opencode` validation stays green under suite load

## Validation
- `cd packages/opencode && bun test`
- `cd packages/opencode && bun typecheck`
