### PR TITLE
fix: cap logs and memory snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,28 @@ const table = sqliteTable("session", {
 - Test actual implementation, do not duplicate logic into tests
 - Tests cannot run from repo root (guard: `do-not-run-tests-from-root`); run from package dirs like `packages/opencode`.
 
+## Memory Panic Triage
+
+If the user reports a panic, OOM, runaway RSS, or unexplained restarts, analyze memory artifacts before guessing.
+
+1. Capture the current state.
+   Run the relevant package-scoped checks first, such as `bun run --cwd packages/opencode profile:memory:wait` for a waiting server or `bun run --cwd packages/opencode profile:memory:workload` for a synthetic reproduction.
+2. Inspect the durable artifacts under `~/.local/share/opencode/log`.
+   Start with `dev.log`, the newest `memory-*.ndjson`, and the newest directories in `~/.local/share/opencode/log/memory/`.
+3. Read the snapshot files in order.
+   `sample.json` shows RSS, heap, PTY count, session counts, and instance-cache pressure.
+   `meta.json` shows why the snapshot was taken and the threshold or trigger state.
+   `ps.txt` shows child-process footprint.
+   On macOS, also inspect `vmmap.txt` and `sample.txt`.
+4. Open `heap.heapsnapshot` only after you know the spike is heap-related.
+   Use Chrome DevTools Memory tooling to inspect retained objects and dominators.
+5. Check disk pressure alongside memory pressure.
+   Inspect `~/.local/share/opencode/worktree`, `~/.local/share/opencode/tool-output`, and `~/.local/share/opencode/log` so you do not misdiagnose a disk-exhaustion crash as a heap leak.
+6. Preserve evidence in the issue or PR.
+   Record exact sizes, timestamps, active session counts, and the snapshot trigger reason.
+
+Do not generate repeated snapshots blindly. Retention keeps only the newest `2` heap snapshot directories, so if an older capture matters, attach or summarize it before reproducing again.
+
 ## Type Checking
 
 - Always run `bun typecheck` from package directories (e.g., `packages/opencode`), never `tsc` directly.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,40 @@ Learn more about [agents](https://opencode.ai/docs/agents).
 
 For more info on how to configure OpenCode, [**head over to our docs**](https://opencode.ai/docs).
 
+### Memory Diagnostics
+
+This fork carries built-in memory profiling helpers intended for leak hunts, panic triage, and long-running session investigations.
+
+Useful commands:
+
+```bash
+bun run --cwd packages/opencode profile:memory
+bun run --cwd packages/opencode profile:memory:wait
+bun run --cwd packages/opencode profile:memory:workload
+```
+
+Artifacts are written under `~/.local/share/opencode/log`:
+
+- `memory-<label>-<timestamp>.ndjson`: rolling NDJSON samples from the memory monitor
+- `memory/<timestamp>/sample.json`: point-in-time process, heap, session, PTY, and instance-cache stats
+- `memory/<timestamp>/meta.json`: trigger reason, threshold, RSS summary, and active-session counts
+- `memory/<timestamp>/ps.txt`: process list captured at snapshot time
+- `memory/<timestamp>/vmmap.txt`: macOS virtual memory summary, when available
+- `memory/<timestamp>/sample.txt`: macOS stack sampling output, when available
+- `memory/<timestamp>/heap.heapsnapshot`: V8 heap snapshot for DevTools Memory analysis
+
+Heap snapshot notes:
+
+- Open `heap.heapsnapshot` in Chrome DevTools or another V8-compatible heap viewer.
+- Use `sample.json` and `meta.json` first to confirm whether the spike is heap, child-process RSS, PTY growth, or instance-cache pressure before drilling into the heap graph.
+- On macOS, `vmmap.txt` and `sample.txt` are often the fastest way to distinguish heap growth from mapped-file or native allocations.
+
+Retention and disk safety:
+
+- Top-level log files in `~/.local/share/opencode/log` are auto-trimmed to a total of `512 MiB`.
+- Heap snapshot directories in `~/.local/share/opencode/log/memory` are capped to the newest `2`.
+- The retention caps are automatic so repeated profiling does not silently exhaust disk space.
+
 ### Contributing
 
 If you're interested in contributing to OpenCode, please read our [contributing docs](./CONTRIBUTING.md) before submitting a pull request.

--- a/packages/opencode/src/diagnostic/memory.ts
+++ b/packages/opencode/src/diagnostic/memory.ts
@@ -14,6 +14,7 @@ import { Process } from "@/util/process"
 const log = Log.create({ service: "memory" })
 
 const mib = 1024 * 1024
+const keep = 2
 
 const run = {
   busy: false,
@@ -143,6 +144,38 @@ function env() {
   }
 }
 
+type Entry = {
+  dir: string
+  time: number
+}
+
+async function prune(input?: {
+  dir?: string
+  keep?: number
+}) {
+  const root = input?.dir ?? path.join(Global.Path.log, "memory")
+  const max = input?.keep ?? keep
+  const list = await fs.readdir(root, { withFileTypes: true }).catch(() => [])
+  const rows = await Promise.all(
+    list
+      .filter((item) => item.isDirectory())
+      .map(async (item) => {
+        const dir = path.join(root, item.name)
+        const stat = await fs.stat(dir).catch(() => undefined)
+        if (!stat) return
+        return {
+          dir,
+          time: stat.mtimeMs,
+        } satisfies Entry
+      }),
+  )
+  const dirs = rows
+    .filter((item): item is Entry => Boolean(item))
+    .sort((a, b) => a.time - b.time)
+  if (dirs.length <= max) return
+  await Promise.all(dirs.slice(0, -max).map((item) => fs.rm(item.dir, { recursive: true, force: true }).catch(() => {})))
+}
+
 export namespace Memory {
   export const TreeProcess = z.object({
     pid: z.number(),
@@ -189,6 +222,8 @@ export namespace Memory {
   })
 
   export type Sample = z.infer<typeof Sample>
+
+  export const trim = prune
 
   export async function sample(input?: { children?: boolean }) {
     const mem = process.memoryUsage()
@@ -255,6 +290,8 @@ export namespace Memory {
           sessions_active: data.session.active,
         })
 
+        await Memory.trim()
+
         return dir
       })
       .finally(() => {
@@ -267,6 +304,10 @@ export namespace Memory {
 
     const cfg = env()
     if (!cfg) return
+
+    void Memory.trim().catch((error) => {
+      log.error("memory trim failed", { error })
+    })
 
     one.file =
       cfg.path || path.join(Global.Path.log, `memory-${label}-${new Date().toISOString().split(".")[0].replace(/:/g, "")}.ndjson`)
@@ -286,6 +327,7 @@ export namespace Memory {
         .then(async () => {
           const data = await sample({ children: cfg.children })
           await fs.appendFile(one.file, JSON.stringify(data) + "\n")
+          await Log.trim()
 
           if (cfg.threshold_mb === undefined) return
           const value = data.tree?.rss_bytes ?? data.rss_bytes

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -52,14 +52,110 @@ export namespace Log {
   export function file() {
     return logpath
   }
+  const max = 512 * 1024 * 1024
+  const step = 1024 * 1024
+  const wait = 5_000
+  let size = 0
+  let time = 0
+  let task: Promise<void> | undefined
+
+  type Entry = {
+    file: string
+    size: number
+    time: number
+  }
+
+  async function entries(dir: string) {
+    const list = await Glob.scan("*", {
+      cwd: dir,
+      absolute: true,
+      include: "file",
+    }).catch(() => [] as string[])
+    const rows = await Promise.all(
+      list
+        .filter((file) => file.endsWith(".log") || file.endsWith(".ndjson"))
+        .map(async (file) => {
+          const stat = await fs.stat(file).catch(() => undefined)
+          if (!stat) return
+          return {
+            file,
+            size: stat.size,
+            time: stat.mtimeMs,
+          } satisfies Entry
+        }),
+    )
+    return rows.filter(Boolean) as Entry[]
+  }
+
+  async function tail(file: string, keep: number) {
+    const stat = await fs.stat(file).catch(() => undefined)
+    if (!stat) return 0
+    if (keep <= 0) {
+      await fs.truncate(file, 0).catch(() => {})
+      return 0
+    }
+    if (stat.size <= keep) return stat.size
+
+    const fd = await fs.open(file, "r")
+    try {
+      const buf = Buffer.allocUnsafe(keep)
+      await fd.read(buf, 0, keep, stat.size - keep)
+      await fs.writeFile(file, buf)
+      return keep
+    } finally {
+      await fd.close().catch(() => {})
+    }
+  }
+
+  export async function trim(input?: {
+    dir?: string
+    max?: number
+    file?: string
+  }) {
+    const dir = input?.dir ?? Global.Path.log
+    const keep = input?.max ?? max
+    const file = input?.file ?? logpath
+    const rows = (await entries(dir)).sort((a, b) => a.time - b.time)
+    let total = rows.reduce((sum, row) => sum + row.size, 0)
+    if (total <= keep) return
+
+    for (const row of rows) {
+      if (total <= keep) return
+      if (row.file === file) continue
+      await fs.unlink(row.file).catch(() => {})
+      total -= row.size
+    }
+
+    if (total <= keep) return
+    const row = rows.find((row) => row.file === file)
+    if (!row) return
+
+    const room = Math.max(0, keep - (total - row.size))
+    total = total - row.size + (await tail(row.file, room))
+    if (total <= keep) return
+  }
+
+  function sweep() {
+    const now = Date.now()
+    if (task) return
+    if (size < step && now - time < wait) return
+    size = 0
+    time = now
+    task = trim().finally(() => {
+      task = undefined
+    })
+  }
+
   let write = (msg: any) => {
     process.stderr.write(msg)
+    size += msg.length
+    sweep()
     return msg.length
   }
 
   export async function init(options: Options) {
     if (options.level) level = options.level
-    cleanup(Global.Path.log)
+    await trim()
     if (options.print) return
     logpath = path.join(
       Global.Path.log,
@@ -71,22 +167,14 @@ export namespace Log {
       return new Promise((resolve, reject) => {
         stream.write(msg, (err) => {
           if (err) reject(err)
-          else resolve(msg.length)
+          else {
+            size += msg.length
+            sweep()
+            resolve(msg.length)
+          }
         })
       })
     }
-  }
-
-  async function cleanup(dir: string) {
-    const files = await Glob.scan("????-??-??T??????.log", {
-      cwd: dir,
-      absolute: true,
-      include: "file",
-    })
-    if (files.length <= 5) return
-
-    const filesToDelete = files.slice(0, -10)
-    await Promise.all(filesToDelete.map((file) => fs.unlink(file).catch(() => {})))
   }
 
   function formatError(error: Error, depth = 0): string {

--- a/packages/opencode/test/memory/retention.test.ts
+++ b/packages/opencode/test/memory/retention.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Memory } from "../../src/diagnostic/memory"
+import { tmpdir } from "../fixture/fixture"
+
+describe("memory retention", () => {
+  test("keeps only the newest snapshot directories", async () => {
+    await using tmp = await tmpdir()
+    const one = path.join(tmp.path, "one")
+    const two = path.join(tmp.path, "two")
+    const three = path.join(tmp.path, "three")
+
+    await fs.mkdir(one, { recursive: true })
+    await fs.mkdir(two, { recursive: true })
+    await fs.mkdir(three, { recursive: true })
+    await fs.writeFile(path.join(one, "meta.json"), "{}")
+    await fs.writeFile(path.join(two, "meta.json"), "{}")
+    await fs.writeFile(path.join(three, "meta.json"), "{}")
+    await fs.utimes(one, new Date("2026-03-01T00:00:00Z"), new Date("2026-03-01T00:00:00Z"))
+    await fs.utimes(two, new Date("2026-03-02T00:00:00Z"), new Date("2026-03-02T00:00:00Z"))
+    await fs.utimes(three, new Date("2026-03-03T00:00:00Z"), new Date("2026-03-03T00:00:00Z"))
+
+    await Memory.trim({
+      dir: tmp.path,
+      keep: 2,
+    })
+
+    expect(await fs.stat(one).catch(() => undefined)).toBeUndefined()
+    expect((await fs.readdir(tmp.path)).sort()).toEqual(["three", "two"])
+  })
+})

--- a/packages/opencode/test/util/log.test.ts
+++ b/packages/opencode/test/util/log.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+describe("util.log", () => {
+  test("deletes old logs and trims the active log to stay within the cap", async () => {
+    await using tmp = await tmpdir()
+    const old = path.join(tmp.path, "old.log")
+    const cur = path.join(tmp.path, "dev.log")
+    await fs.writeFile(old, "old!")
+    await fs.writeFile(cur, "0123456789")
+    await fs.utimes(old, new Date("2026-03-01T00:00:00Z"), new Date("2026-03-01T00:00:00Z"))
+    await fs.utimes(cur, new Date("2026-03-02T00:00:00Z"), new Date("2026-03-02T00:00:00Z"))
+
+    await Log.trim({
+      dir: tmp.path,
+      max: 8,
+      file: cur,
+    })
+
+    expect(await fs.stat(old).catch(() => undefined)).toBeUndefined()
+    expect(await fs.readFile(cur, "utf-8")).toBe("23456789")
+  })
+})


### PR DESCRIPTION
## Summary
- cap retained log files under `~/.local/share/opencode/log` to `512 MiB`
- cap retained heap snapshot directories under `~/.local/share/opencode/log/memory` to the newest `2`
- document memory profiling artifacts and panic-triage workflow in `README.md` and `AGENTS.md`

## Testing
- `bun test test/server/global-memory.test.ts test/util/log.test.ts test/memory/retention.test.ts`
- `bun typecheck`

Closes #90