### PR TITLE
fix: stabilize auto review workflow

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -4,80 +4,48 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: review-${{ github.repository }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
-  check-guidelines:
+  review:
     if: |
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/review') &&
       contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
+      id-token: write
       contents: read
-      pull-requests: write
+      pull-requests: read
+      issues: read
+    timeout-minutes: 15
     steps:
-      - name: Get PR number
-        id: pr-number
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
-            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          else
-            echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
-          fi
-
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
-      - uses: ./.github/actions/setup-bun
-
-      - name: Install opencode
-        run: curl -fsSL https://opencode.ai/install | bash
-
-      - name: Get PR details
-        id: pr-details
-        run: |
-          gh api /repos/${{ github.repository }}/pulls/${{ steps.pr-number.outputs.number }} > pr_data.json
-          echo "title=$(jq -r .title pr_data.json)" >> $GITHUB_OUTPUT
-          echo "sha=$(jq -r .head.sha pr_data.json)" >> $GITHUB_OUTPUT
+      - name: Review pull request
+        uses: anomalyco/opencode/github@latest
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check PR guidelines compliance
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENCODE_PERMISSION: '{ "bash": {  "*": "deny", "gh*": "allow", "gh pr review*": "deny" } }'
-          PR_TITLE: ${{ steps.pr-details.outputs.title }}
-        run: |
-          PR_BODY=$(jq -r .body pr_data.json)
-          opencode run -m anthropic/claude-opus-4-5 "A new pull request has been created: '${PR_TITLE}'
+          OPENCODE_PERMISSION: '{"bash":"deny","edit":"deny","task":"deny"}'
+        with:
+          model: github-copilot/gpt-5.4
+          variant: xhigh
+          prompt: |
+            Review this pull request.
 
-          <pr-number>
-          ${{ steps.pr-number.outputs.number }}
-          </pr-number>
+            Answer these questions:
+            1. Were these changes necessary?
+            2. Is the implementation complete and done in the most optimal way for this repository?
+            3. What, if anything, should still be improved in this branch or pull request?
 
-          <pr-description>
-          $PR_BODY
-          </pr-description>
+            Review the actual changed code, not just the PR body. Read the full changed files before judging them.
+            Focus on concrete bugs, regressions, missing tests, unnecessary complexity, and obvious maintainability issues in the changed code.
+            Be concise, direct, and specific. Keep this to a single final review response. Do not create inline review comments, do not make code changes, and do not use shell commands.
 
-          Please check all the code changes in this pull request against the style guide, also look for any bugs if they exist. Diffs are important but make sure you read the entire file to get proper context. Make it clear the suggestions are merely suggestions and the human can decide what to do
-
-          When critiquing code against the style guide, be sure that the code is ACTUALLY in violation, don't complain about else statements if they already use early returns there. You may complain about excessive nesting though, regardless of else statement usage.
-          When critiquing code style don't be a zealot, we don't like "let" statements but sometimes they are the simplest option, if someone does a bunch of nesting with let, they should consider using iife (see packages/opencode/src/util.iife.ts)
-
-          Use the gh cli to create comments on the files for the violations. Try to leave the comment on the exact line number. If you have a suggested fix include it in a suggestion code block.
-          If you are writing suggested fixes, BE SURE THAT the change you are recommending is actually valid typescript, often I have seen missing closing "}" or other syntax errors.
-          Generally, write a comment instead of writing suggested change if you can help it.
-
-          Command MUST be like this.
-          \`\`\`
-          gh api \
-            --method POST \
-            -H \"Accept: application/vnd.github+json\" \
-            -H \"X-GitHub-Api-Version: 2022-11-28\" \
-            /repos/${{ github.repository }}/pulls/${{ steps.pr-number.outputs.number }}/comments \
-            -f 'body=[summary of issue]' -f 'commit_id=${{ steps.pr-details.outputs.sha }}' -f 'path=[path-to-file]' -F \"line=[line]\" -f 'side=RIGHT'
-          \`\`\`
-
-          Only create comments for actual violations. If the code follows all guidelines, comment on the issue using gh cli: 'lgtm' AND NOTHING ELSE!!!!."
+            If nothing needs attention, say `LGTM` and briefly state why.


### PR DESCRIPTION
## Summary
- replace the ad-hoc `/review` runner with the standard `anomalyco/opencode/github@latest` action
- pin review runs to `github-copilot/gpt-5.4` with `variant: xhigh`
- collapse duplicate `/review` runs with workflow concurrency and force a single non-editing final review response

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/review.yml"); puts "ok"'

Closes #85