### PR TITLE
fix(app): auto-show git workspaces

### DIFF
--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -982,14 +982,18 @@ export async function openProjectMenu(page: Page, projectSlug: string) {
 }
 
 export async function setWorkspacesEnabled(page: Page, projectSlug: string, enabled: boolean) {
-  const current = await page
-    .getByRole("button", { name: "New workspace" })
-    .first()
-    .isVisible()
-    .then((x) => x)
-    .catch(() => false)
+  const state = async () => {
+    const menu = await openProjectMenu(page, projectSlug)
+    const toggle = menu.locator(projectWorkspacesToggleSelector(projectSlug)).first()
+    await expect(toggle).toBeVisible()
+    const text = ((await toggle.textContent()) ?? "").trim().toLowerCase()
+    await page.keyboard.press("Escape").catch(() => undefined)
+    if (text.includes("disable")) return true
+    if (text.includes("enable")) return false
+    throw new Error(`Unexpected workspaces toggle label for ${projectSlug}: ${text}`)
+  }
 
-  if (current === enabled) return
+  if ((await state()) === enabled) return
 
   const flip = async (timeout?: number) => {
     const menu = await openProjectMenu(page, projectSlug)
@@ -1003,9 +1007,7 @@ export async function setWorkspacesEnabled(page: Page, projectSlug: string, enab
     .catch(() => false)
 
   if (!flipped) await flip()
-
-  const expected = enabled ? "New workspace" : "New session"
-  await expect(page.getByRole("button", { name: expected }).first()).toBeVisible()
+  await expect.poll(() => state(), { timeout: 10_000 }).toBe(enabled)
 }
 
 export async function openWorkspaceMenu(page: Page, workspaceSlug: string) {

--- a/packages/app/e2e/projects/workspaces.spec.ts
+++ b/packages/app/e2e/projects/workspaces.spec.ts
@@ -17,10 +17,28 @@ import {
   setWorkspacesEnabled,
   slugFromUrl,
   waitDir,
+  waitSession,
   waitSlug,
 } from "../actions"
 import { dropdownMenuContentSelector, inlineInputSelector, workspaceItemSelector } from "../selectors"
 import { createSdk, dirSlug } from "../utils"
+
+async function waitWorkspaceItem(page: Page, slug: string) {
+  await expect
+    .poll(
+      async () => {
+        const item = page.locator(workspaceItemSelector(slug)).first()
+        try {
+          await item.hover({ timeout: 500 })
+          return true
+        } catch {
+          return false
+        }
+      },
+      { timeout: 60_000 },
+    )
+    .toBe(true)
+}
 
 async function setupWorkspaceTest(page: Page, project: { slug: string }) {
   const rootSlug = project.slug
@@ -33,21 +51,7 @@ async function setupWorkspaceTest(page: Page, project: { slug: string }) {
   await waitDir(page, next.directory)
 
   await openSidebar(page)
-
-  await expect
-    .poll(
-      async () => {
-        const item = page.locator(workspaceItemSelector(next.slug)).first()
-        try {
-          await item.hover({ timeout: 500 })
-          return true
-        } catch {
-          return false
-        }
-      },
-      { timeout: 60_000 },
-    )
-    .toBe(true)
+  await waitWorkspaceItem(page, next.slug)
 
   return { rootSlug, slug: next.slug, directory: next.directory }
 }
@@ -58,16 +62,35 @@ test("can enable and disable workspaces from project menu", async ({ page, withP
   await withProject(async ({ slug }) => {
     await openSidebar(page)
 
-    await expect(page.getByRole("button", { name: "New session" }).first()).toBeVisible()
-    await expect(page.getByRole("button", { name: "New workspace" })).toHaveCount(0)
-
-    await setWorkspacesEnabled(page, slug, true)
     await expect(page.getByRole("button", { name: "New workspace" }).first()).toBeVisible()
-    await expect(page.locator(workspaceItemSelector(slug)).first()).toBeVisible()
+    await waitWorkspaceItem(page, slug)
 
     await setWorkspacesEnabled(page, slug, false)
     await expect(page.getByRole("button", { name: "New session" }).first()).toBeVisible()
     await expect(page.locator(workspaceItemSelector(slug))).toHaveCount(0)
+
+    await setWorkspacesEnabled(page, slug, true)
+    await expect(page.getByRole("button", { name: "New workspace" }).first()).toBeVisible()
+    await waitWorkspaceItem(page, slug)
+  })
+})
+
+test("existing git workspaces auto-show after reload", async ({ page, withProject }) => {
+  await page.setViewportSize({ width: 1400, height: 800 })
+
+  await withProject(async ({ directory, slug, trackDirectory }) => {
+    const created = await createSdk(directory).worktree.create().then((result) => result.data)
+    if (!created?.directory) throw new Error("Failed to create workspace")
+
+    trackDirectory(created.directory)
+
+    await page.reload()
+    await waitSession(page, { directory })
+    await openSidebar(page)
+
+    await expect(page.getByRole("button", { name: "New workspace" }).first()).toBeVisible()
+    await waitWorkspaceItem(page, slug)
+    await waitWorkspaceItem(page, dirSlug(created.directory))
   })
 })
 

--- a/packages/app/src/context/layout.test.ts
+++ b/packages/app/src/context/layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
-import { createSessionKeyReader, ensureSessionKey, pruneSessionKeys } from "./layout"
+import { createSessionKeyReader, ensureSessionKey, pruneSessionKeys, workspaceState } from "./layout"
 
 describe("layout session-key helpers", () => {
   test("couples touch and scroll seed in order", () => {
@@ -65,5 +65,20 @@ describe("pruneSessionKeys", () => {
     })
 
     expect(drop).toEqual([])
+  })
+})
+
+describe("workspaceState", () => {
+  test("prefers stored values over git fallbacks", () => {
+    expect(workspaceState(false, true, true)).toBe(false)
+  })
+
+  test("uses git fallback when no per-project value exists", () => {
+    expect(workspaceState(undefined, true, false)).toBe(true)
+  })
+
+  test("falls back to sidebar default when project and git values are unset", () => {
+    expect(workspaceState(undefined, undefined, false)).toBe(false)
+    expect(workspaceState(undefined, undefined, true)).toBe(true)
   })
 })

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -90,6 +90,10 @@ export function pruneSessionKeys(input: {
     .slice(input.max)
 }
 
+export function workspaceState(value?: boolean, fallback?: boolean, defaults?: boolean) {
+  return value ?? fallback ?? defaults ?? false
+}
+
 function nextSessionTabsForOpen(current: SessionTabs | undefined, tab: string): SessionTabs {
   const all = current?.all ?? []
   if (tab === "review") return { all: all.filter((x) => x !== "review"), active: tab }
@@ -599,14 +603,14 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         resize(width: number) {
           setStore("sidebar", "width", width)
         },
-        workspaces(directory: string) {
-          return () => store.sidebar.workspaces[directory] ?? store.sidebar.workspacesDefault ?? false
+        workspaces(directory: string, fallback?: boolean) {
+          return () => workspaceState(store.sidebar.workspaces[directory], fallback, store.sidebar.workspacesDefault)
         },
         setWorkspaces(directory: string, value: boolean) {
           setStore("sidebar", "workspaces", directory, value)
         },
-        toggleWorkspaces(directory: string) {
-          const current = store.sidebar.workspaces[directory] ?? store.sidebar.workspacesDefault ?? false
+        toggleWorkspaces(directory: string, fallback?: boolean) {
+          const current = workspaceState(store.sidebar.workspaces[directory], fallback, store.sidebar.workspacesDefault)
           setStore("sidebar", "workspaces", directory, !current)
         },
       },

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -633,7 +633,7 @@ export default function Layout(props: ParentProps) {
     const project = currentProject()
     if (!project) return false
     if (project.vcs !== "git") return false
-    return layout.sidebar.workspaces(project.worktree)()
+    return layout.sidebar.workspaces(project.worktree, true)()
   })
 
   const visibleSessionDirs = createMemo(() => {
@@ -661,7 +661,7 @@ export default function Layout(props: ParentProps) {
           workspaceKey(item.worktree) === key || item.sandboxes?.some((sandbox) => workspaceKey(sandbox) === key),
       )
       if (!project) continue
-      if (project.vcs === "git" && layout.sidebar.workspaces(project.worktree)()) continue
+      if (project.vcs === "git" && layout.sidebar.workspaces(project.worktree, true)()) continue
       setStore("workspaceExpanded", directory, false)
     }
   })
@@ -1157,8 +1157,8 @@ export default function Layout(props: ParentProps) {
           const project = currentProject()
           if (!project) return
           if (project.vcs !== "git") return
-          const wasEnabled = layout.sidebar.workspaces(project.worktree)()
-          layout.sidebar.toggleWorkspaces(project.worktree)
+          const wasEnabled = layout.sidebar.workspaces(project.worktree, true)()
+          layout.sidebar.toggleWorkspaces(project.worktree, true)
           showToast({
             title: wasEnabled
               ? language.t("toast.workspace.disabled.title")
@@ -1471,13 +1471,14 @@ export default function Layout(props: ParentProps) {
   }
 
   function toggleProjectWorkspaces(project: LocalProject) {
-    const enabled = layout.sidebar.workspaces(project.worktree)()
+    const fallback = project.vcs === "git" ? true : undefined
+    const enabled = layout.sidebar.workspaces(project.worktree, fallback)()
     if (enabled) {
-      layout.sidebar.toggleWorkspaces(project.worktree)
+      layout.sidebar.toggleWorkspaces(project.worktree, fallback)
       return
     }
     if (project.vcs !== "git") return
-    layout.sidebar.toggleWorkspaces(project.worktree)
+    layout.sidebar.toggleWorkspaces(project.worktree, fallback)
   }
 
   const showEditProjectDialog = (project: LocalProject) => {
@@ -2050,7 +2051,7 @@ export default function Layout(props: ParentProps) {
     closeProject,
     showEditProjectDialog,
     toggleProjectWorkspaces,
-    workspacesEnabled: (project) => project.vcs === "git" && layout.sidebar.workspaces(project.worktree)(),
+    workspacesEnabled: (project) => project.vcs === "git" && layout.sidebar.workspaces(project.worktree, true)(),
     workspaceIds,
     workspaceLabel,
     sessionProps: {
@@ -2105,7 +2106,7 @@ export default function Layout(props: ParentProps) {
       const item = project()
       if (!item) return false
       if (item.vcs !== "git") return false
-      return layout.sidebar.workspaces(item.worktree)()
+      return layout.sidebar.workspaces(item.worktree, true)()
     })
     const canToggle = createMemo(() => {
       const item = project()


### PR DESCRIPTION
Closes #42

## Summary
- add a reusable workspace-state resolver so git projects can treat an unset sidebar override as enabled
- pass the git fallback through layout/sidebar callers while keeping explicit false overrides authoritative
- cover the default-enabled behavior with unit coverage and reload/projects-switch e2e coverage

## Testing
- bun test --preload ./happydom.ts ./src/context/layout.test.ts
- bun typecheck
- TMPDIR=/Volumes/Dzianis-3/macbook/tmp bun test:e2e:local -- -- e2e/projects/workspaces.spec.ts e2e/projects/projects-switch.spec.ts