### PR TITLE
fix(provider): restore gpt-5.4 xhigh reasoning variants

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -333,6 +333,8 @@ export namespace ProviderTransform {
     if (!model.capabilities.reasoning) return {}
 
     const id = model.id.toLowerCase()
+    const gpt5 = /(^|\/)gpt-5(?:[.-]|$)/.test(id)
+    const xhigh = /(^|\/)gpt-5\.(2|3|4)(?:[.-]|$)/.test(id) || (gpt5 && model.release_date >= "2025-12-04")
     const isAnthropicAdaptive = ["opus-4-6", "opus-4.6", "sonnet-4-6", "sonnet-4.6"].some((v) =>
       model.api.id.includes(v),
     )
@@ -472,8 +474,11 @@ export namespace ProviderTransform {
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure
         if (id === "o1-mini") return {}
         const azureEfforts = ["low", "medium", "high"]
-        if (id.includes("gpt-5-") || id === "gpt-5") {
+        if (gpt5) {
           azureEfforts.unshift("minimal")
+        }
+        if (xhigh) {
+          azureEfforts.push("xhigh")
         }
         return Object.fromEntries(
           azureEfforts.map((effort) => [
@@ -490,17 +495,17 @@ export namespace ProviderTransform {
         if (id === "gpt-5-pro") return {}
         const openaiEfforts = iife(() => {
           if (id.includes("codex")) {
-            if (id.includes("5.2") || id.includes("5.3")) return [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+            if (xhigh) return [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
             return WIDELY_SUPPORTED_EFFORTS
           }
           const arr = [...WIDELY_SUPPORTED_EFFORTS]
-          if (id.includes("gpt-5-") || id === "gpt-5") {
+          if (gpt5) {
             arr.unshift("minimal")
           }
           if (model.release_date >= "2025-11-13") {
             arr.unshift("none")
           }
-          if (model.release_date >= "2025-12-04") {
+          if (xhigh) {
             arr.push("xhigh")
           }
           return arr

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2217,6 +2217,26 @@ describe("ProviderTransform.variants", () => {
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
     })
+
+    test("gpt-5.4 includes xhigh", () => {
+      const model = createMockModel({
+        id: "gpt-5.4",
+        release_date: "2026-03-05",
+        providerID: "azure",
+        api: {
+          id: "gpt-5.4",
+          url: "https://azure.com",
+          npm: "@ai-sdk/azure",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high", "xhigh"])
+      expect(result.xhigh).toEqual({
+        reasoningEffort: "xhigh",
+        reasoningSummary: "auto",
+        include: ["reasoning.encrypted_content"],
+      })
+    })
   })
 
   describe("@ai-sdk/openai", () => {
@@ -2282,6 +2302,26 @@ describe("ProviderTransform.variants", () => {
       })
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
+    })
+
+    test("gpt-5.4 includes minimal and xhigh", () => {
+      const model = createMockModel({
+        id: "gpt-5.4",
+        providerID: "openai",
+        api: {
+          id: "gpt-5.4",
+          url: "https://api.openai.com",
+          npm: "@ai-sdk/openai",
+        },
+        release_date: "2026-03-05",
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"])
+      expect(result.xhigh).toEqual({
+        reasoningEffort: "xhigh",
+        reasoningSummary: "auto",
+        include: ["reasoning.encrypted_content"],
+      })
     })
   })
 


### PR DESCRIPTION
## Summary
- restore `xhigh` reasoning variants for OpenAI and Azure GPT-5.4 models
- treat dotted GPT-5 ids like `gpt-5.4` the same as dashed GPT-5 ids when building reasoning variants
- add regression tests for Azure and OpenAI `gpt-5.4`

## Rationale
The current provider transform only recognized `gpt-5` and `gpt-5-*` when adding `minimal`, and Azure no longer exposed `xhigh` at all. That caused `gpt-5.4` to regress back to `high`-only reasoning in OpenAI/Azure paths.

## Testing
- `cd packages/opencode && bun test test/provider/transform.test.ts`
- `cd packages/opencode && bun typecheck` *(blocked on existing `origin/dev` dependency issues for `@gitlab/opencode-gitlab-auth` and `@gitlab/gitlab-ai-provider`, not caused by this patch)*

Refs #85