### PR TITLE
fix: load existing sessions in serve webapp

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -32,6 +32,7 @@ import { Permission } from "@/permission"
 import { Global } from "@/global"
 import type { LanguageModelV2Usage } from "@ai-sdk/provider"
 import { iife } from "@/util/iife"
+import { Filesystem } from "@/util/filesystem"
 
 export namespace Session {
   const log = Log.create({ service: "session" })
@@ -563,12 +564,14 @@ export namespace Session {
   }) {
     const project = Instance.project
     const conditions = [eq(SessionTable.project_id, project.id)]
+    const workspace = WorkspaceContext.workspaceID
+    const directory = input?.directory ? Filesystem.resolve(input.directory) : undefined
 
-    if (WorkspaceContext.workspaceID) {
-      conditions.push(eq(SessionTable.workspace_id, WorkspaceContext.workspaceID))
+    if (workspace) {
+      conditions.push(or(eq(SessionTable.workspace_id, workspace), isNull(SessionTable.workspace_id))!)
     }
-    if (input?.directory) {
-      conditions.push(eq(SessionTable.directory, input.directory))
+    if (directory) {
+      conditions.push(eq(SessionTable.directory, directory))
     }
     if (input?.roots) {
       conditions.push(isNull(SessionTable.parent_id))
@@ -606,9 +609,10 @@ export namespace Session {
     archived?: boolean
   }) {
     const conditions: SQL[] = []
+    const directory = input?.directory ? Filesystem.resolve(input.directory) : undefined
 
-    if (input?.directory) {
-      conditions.push(eq(SessionTable.directory, input.directory))
+    if (directory) {
+      conditions.push(eq(SessionTable.directory, directory))
     }
     if (input?.roots) {
       conditions.push(isNull(SessionTable.parent_id))

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -3,6 +3,8 @@ import path from "path"
 import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session"
 import { Log } from "../../src/util/log"
+import { WorkspaceContext } from "../../src/control-plane/workspace-context"
+import { WorkspaceID } from "../../src/control-plane/schema"
 
 const projectRoot = path.join(__dirname, "../..")
 Log.init({ print: false })
@@ -25,6 +27,24 @@ describe("Session.list", () => {
 
         expect(ids).toContain(first.id)
         expect(ids).not.toContain(second.id)
+      },
+    })
+  })
+
+  test("normalizes directory filter aliases", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({ title: "alias-filter-session" })
+        const alias = `${projectRoot}${path.sep}..${path.sep}${path.basename(projectRoot)}`
+
+        const sessions = await Instance.provide({
+          directory: alias,
+          fn: async () => [...Session.list({ directory: alias })],
+        })
+        const ids = sessions.map((s) => s.id)
+
+        expect(ids).toContain(session.id)
       },
     })
   })
@@ -84,6 +104,28 @@ describe("Session.list", () => {
 
         const sessions = [...Session.list({ limit: 2 })]
         expect(sessions.length).toBe(2)
+      },
+    })
+  })
+
+  test("includes unscoped sessions inside workspace context", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const workspace = WorkspaceID.ascending()
+        const scoped = await Session.create({ title: "workspace-session", workspaceID: workspace })
+        const legacy = await Session.create({ title: "legacy-session" })
+        const other = await Session.create({ title: "other-workspace-session", workspaceID: WorkspaceID.ascending() })
+
+        const sessions = await WorkspaceContext.provide({
+          workspaceID: workspace,
+          fn: async () => [...Session.list({})],
+        })
+        const ids = sessions.map((s) => s.id)
+
+        expect(ids).toContain(scoped.id)
+        expect(ids).toContain(legacy.id)
+        expect(ids).not.toContain(other.id)
       },
     })
   })


### PR DESCRIPTION
## Summary
- normalize session directory filters before querying, so alias paths (for example symlink/`..`/`/tmp` forms) still match stored session directories
- include legacy unscoped sessions (`workspace_id IS NULL`) when listing sessions inside a workspace context
- add regression coverage for both directory alias filtering and workspace-context legacy visibility

## Testing
- `bun test test/server/session-list.test.ts` (from `packages/opencode`)
- `bun typecheck` (from `packages/opencode`)
- HTTP E2E check against local `opencode serve`:
  - created a session under `/tmp/...`
  - verified `GET /session?directory=/tmp/...` returns it
  - verified `GET /session?directory=/tmp/...&workspace=...` also returns it

Closes #97
