### PR TITLE
fix(app): auto-open project when opening recent sessions

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1799,6 +1799,18 @@ export default function Layout(props: ParentProps) {
 
   createEffect(
     on(
+      () => [pageReady(), layoutReady(), currentDir()] as const,
+      ([ready, loaded, directory]) => {
+        if (!ready || !loaded) return
+        if (!directory) return
+        layout.projects.open(directory)
+      },
+      { defer: true },
+    ),
+  )
+
+  createEffect(
+    on(
       () => {
         return [pageReady(), route().slug, params.id, currentProject()?.worktree, currentDir()] as const
       },


### PR DESCRIPTION
## Summary
- auto-open the route directory as a project once layout and route state are ready
- ensure sessions opened from Recent flows (recent sidebar and /recent page) register their project in the sidebar project list

## Testing
- bun test v1.3.11 (af24e281)
- 
- opencode server listening on http://127.0.0.1:56634



Running 3 tests using 1 worker





[1A[2K[1/3] [chromium] › e2e/sidebar/sidebar-recent-panel.spec.ts:7:1 › recent sidebar tile shows global sessions across projects
[1A[2K[2/3] [chromium] › e2e/sidebar/sidebar-recent-panel.spec.ts:64:1 › recent sidebar shows child sessions nested under their parent
[1A[2K[3/3] [chromium] › e2e/sidebar/sidebar-recent-panel.spec.ts:102:1 › archiving from recent sidebar removes the thread immediately
[1A[2K  3 passed (13.3s)

Closes #101