### PR TITLE
feat(app): surface recent models in picker (#19935)

### DIFF
--- a/packages/app/e2e/models/model-picker.spec.ts
+++ b/packages/app/e2e/models/model-picker.spec.ts
@@ -46,3 +46,19 @@ test("smoke model selection updates prompt footer", async ({ page, gotoSession }
   await expect(dialogAgain).toBeVisible()
   await expect(dialogAgain.locator(`[data-slot="list-item"][data-key="${key}"][data-selected="true"]`)).toBeVisible()
 })
+
+test("recent models are shown first in the model picker", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  await page.locator(promptSelector).click()
+  await page.keyboard.type("/model")
+
+  const command = page.locator('[data-slash-id="model.choose"]')
+  await expect(command).toBeVisible()
+  await command.hover()
+  await page.keyboard.press("Enter")
+
+  const dialog = page.getByRole("dialog")
+  await expect(dialog).toBeVisible()
+  await expect(dialog.locator('[data-slot="list-item"]').first()).toHaveAttribute("data-key", "opencode:big-pickle")
+})

--- a/packages/app/src/components/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog-select-model.tsx
@@ -15,6 +15,12 @@ import { DialogManageModels } from "./dialog-manage-models"
 import { ModelTooltip } from "./model-tooltip"
 import { useLanguage } from "@/context/language"
 
+type ModelItem = NonNullable<ReturnType<ModelState["current"]>>
+
+function itemKey(item: ModelItem) {
+  return `${item.provider.id}:${item.id}`
+}
+
 const isFree = (provider: string, cost: { input: number } | undefined) =>
   provider === "opencode" && (!cost || cost.input === 0)
 
@@ -29,6 +35,7 @@ const ModelList: Component<{
 }> = (props) => {
   const model = props.model ?? useLocal().model
   const language = useLanguage()
+  const recent = () => language.t("dialog.model.group.recent")
 
   const models = createMemo(() =>
     model
@@ -37,18 +44,34 @@ const ModelList: Component<{
       .filter((m) => (props.provider ? m.provider.id === props.provider : true)),
   )
 
+  const recents = createMemo(() =>
+    new Map(
+      model.recent().flatMap((item, index) => {
+        if (!item) return []
+        return [[itemKey(item), index] as const]
+      }),
+    ),
+  )
+
   return (
     <List
       class={`flex-1 min-h-0 [&_[data-slot=list-scroll]]:flex-1 [&_[data-slot=list-scroll]]:min-h-0 ${props.class ?? ""}`}
       search={{ placeholder: language.t("dialog.model.search.placeholder"), autofocus: true, action: props.action }}
       emptyMessage={language.t("dialog.model.empty")}
-      key={(x) => `${x.provider.id}:${x.id}`}
+      key={itemKey}
       items={models}
       current={model.current()}
       filterKeys={["provider.name", "name", "id"]}
-      sortBy={(a, b) => a.name.localeCompare(b.name)}
-      groupBy={(x) => x.provider.name}
+      sortBy={(a, b) => {
+        const ai = recents().get(itemKey(a))
+        const bi = recents().get(itemKey(b))
+        if (ai !== undefined && bi !== undefined) return ai - bi
+        return a.name.localeCompare(b.name)
+      }}
+      groupBy={(item) => (recents().has(itemKey(item)) ? recent() : item.provider.name)}
       sortGroupsBy={(a, b) => {
+        if (a.category === recent()) return -1
+        if (b.category === recent()) return 1
         const aProvider = a.items[0].provider.id
         const bProvider = b.items[0].provider.id
         if (popularProviders.includes(aProvider) && !popularProviders.includes(bProvider)) return -1

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -115,6 +115,7 @@ export const dict = {
   "dialog.model.select.title": "Select model",
   "dialog.model.search.placeholder": "Search models",
   "dialog.model.empty": "No model results",
+  "dialog.model.group.recent": "Recent",
   "dialog.model.manage": "Manage models",
   "dialog.model.manage.description": "Customize which models appear in the model selector.",
   "dialog.model.manage.provider.toggle": "Toggle all {{provider}} models",


### PR DESCRIPTION
## Summary
- surface recently used models at the top of the app model picker under a dedicated Recent section
- preserve recency order for recent models while keeping the existing provider grouping for the rest of the list
- add an e2e check that verifies the seeded recent model appears first in the picker

## Testing
- bun typecheck
- bun test:e2e:local -- -- e2e/models/model-picker.spec.ts