### PR TITLE
fix: backfill azure/gpt-5.3-codex in provider model lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Learn more about [agents](https://opencode.ai/docs/agents).
 
 For more info on how to configure OpenCode, [**head over to our docs**](https://opencode.ai/docs).
 
+### MCP Lifecycle
+
+Local MCP servers are cleaned up automatically in this fork. OpenCode can close a local MCP child process when the shared client is released, during shutdown, and it also reaps idle shared clients after `10` minutes by default. You can raise or lower that idle window with `OPENCODE_MCP_IDLE_MS` (milliseconds).
+
 ### Memory Diagnostics
 
 This fork carries built-in memory profiling helpers intended for leak hunts, panic triage, and long-running session investigations.

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -836,7 +836,7 @@ export namespace Provider {
     })
   export type Info = z.infer<typeof Info>
 
-  const MODELS_DEV_BACKFILLS = {
+  const MODELS_DEV_BACKFILLS: Record<string, Record<string, ModelsDev.Model>> = {
     azure: {
       "gpt-5.3-codex": {
         id: "gpt-5.3-codex",
@@ -863,7 +863,7 @@ export namespace Provider {
         options: {},
       },
     },
-  } satisfies Record<string, Record<string, ModelsDev.Model>>
+  }
 
   function withModelsDevBackfills(provider: ModelsDev.Provider): ModelsDev.Provider {
     const backfills = MODELS_DEV_BACKFILLS[provider.id]

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -836,6 +836,47 @@ export namespace Provider {
     })
   export type Info = z.infer<typeof Info>
 
+  const MODELS_DEV_BACKFILLS = {
+    azure: {
+      "gpt-5.3-codex": {
+        id: "gpt-5.3-codex",
+        name: "GPT-5.3 Codex",
+        family: "gpt-codex",
+        attachment: false,
+        reasoning: true,
+        temperature: false,
+        tool_call: true,
+        release_date: "2026-02-24",
+        modalities: {
+          input: ["text", "image"],
+          output: ["text"],
+        },
+        cost: {
+          input: 1.75,
+          output: 14,
+          cache_read: 0.175,
+        },
+        limit: {
+          context: 400000,
+          output: 128000,
+        },
+        options: {},
+      },
+    },
+  } satisfies Record<string, Record<string, ModelsDev.Model>>
+
+  function withModelsDevBackfills(provider: ModelsDev.Provider): ModelsDev.Provider {
+    const backfills = MODELS_DEV_BACKFILLS[provider.id]
+    if (!backfills) return provider
+    return {
+      ...provider,
+      models: {
+        ...backfills,
+        ...provider.models,
+      },
+    }
+  }
+
   function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model): Model {
     const m: Model = {
       id: ModelID.make(model.id),
@@ -904,13 +945,14 @@ export namespace Provider {
   }
 
   export function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
+    const normalized = withModelsDevBackfills(provider)
     return {
-      id: ProviderID.make(provider.id),
+      id: ProviderID.make(normalized.id),
       source: "custom",
-      name: provider.name,
-      env: provider.env ?? [],
+      name: normalized.name,
+      env: normalized.env ?? [],
       options: {},
-      models: mapValues(provider.models, (model) => fromModelsDevModel(provider, model)),
+      models: mapValues(normalized.models, (model) => fromModelsDevModel(normalized, model)),
     }
   }
 

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -34,6 +34,43 @@ test("provider loaded from env variable", async () => {
   })
 })
 
+test("azure/gpt-5.3-codex is backfilled when provider metadata is stale", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("AZURE_RESOURCE_NAME", "test-resource")
+      Env.set("AZURE_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const providers = await Provider.list()
+      const azure = providers[ProviderID.azure]
+      expect(azure).toBeDefined()
+      expect(azure.source).toBe("env")
+
+      const model = azure.models["gpt-5.3-codex"]
+      expect(model).toBeDefined()
+      expect(model.api.id).toBe("gpt-5.3-codex")
+      expect(model.api.npm).toBe("@ai-sdk/azure")
+      expect(model.limit.context).toBe(400000)
+      expect(model.variants?.xhigh).toEqual({
+        reasoningEffort: "xhigh",
+        reasoningSummary: "auto",
+        include: ["reasoning.encrypted_content"],
+      })
+    },
+  })
+})
+
 test("provider loaded from config with apiKey option", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2321,6 +2321,25 @@ describe("ProviderTransform.variants", () => {
       expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
     })
 
+    test("gpt-5.3-codex includes xhigh", () => {
+      const model = createMockModel({
+        id: "gpt-5.3-codex",
+        providerID: "azure",
+        api: {
+          id: "gpt-5.3-codex",
+          url: "https://azure.com",
+          npm: "@ai-sdk/azure",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high", "xhigh"])
+      expect(result.xhigh).toEqual({
+        reasoningEffort: "xhigh",
+        reasoningSummary: "auto",
+        include: ["reasoning.encrypted_content"],
+      })
+    })
+
     test("gpt-5.4 includes xhigh", () => {
       const model = createMockModel({
         id: "gpt-5.4",

--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -90,6 +90,10 @@ Add local MCP servers using `type` to `"local"` within the MCP object.
 
 The command is how the local MCP server is started. You can also pass in a list of environment variables as well.
 
+:::note
+Local MCP processes are not kept alive forever. OpenCode closes local MCP clients when they are released, during shutdown, and it reaps idle shared clients after `10` minutes by default. You can tune that idle timeout with `OPENCODE_MCP_IDLE_MS` (milliseconds).
+:::
+
 For example, here's how you can add the test [`@modelcontextprotocol/server-everything`](https://www.npmjs.com/package/@modelcontextprotocol/server-everything) MCP server.
 
 ```jsonc title="opencode.jsonc"


### PR DESCRIPTION
### Issue for this PR

Closes #106

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The Azure provider list can miss `azure/gpt-5.3-codex` when the local `models.dev` payload is older than the latest Azure catalog. This change backfills that model in the core provider normalization path so the provider list, model picker, and `opencode models azure` still expose it even when metadata lags.

It also adds regression coverage for that stale-metadata case and documents the local MCP idle cleanup behavior that this fork carries.

### How did you verify your code works?

- Ran `bun test test/provider/provider.test.ts test/provider/transform.test.ts`
- Ran `bun run typecheck`
- Verified the CLI lists the model against the stale fixture with:
  `OPENCODE_MODELS_PATH=/Users/engineer/workspace/opencode/packages/opencode/test/tool/fixtures/models-api.json AZURE_RESOURCE_NAME=test-resource AZURE_API_KEY=test-api-key bun run --cwd packages/opencode --conditions=browser src/index.ts models azure | rg '^azure/gpt-5\\.3-codex$'`

### Screenshots / recordings

N/A. This is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
