### PR TITLE
feat(github): auto-build issue prompts for assigned/opened events

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,177 @@
+# OpenCode GitHub Webhook Integration — Design
+
+## Goal
+
+When a GitHub issue is assigned to the bot (or a comment with `/oc` prefix is posted),
+`opencode serve` receives the webhook, runs the AI agent locally, pushes a branch,
+creates a PR, and comments on the issue — all without CI or GitHub Actions.
+
+## Target Architecture
+
+```
+GitHub.com                          opencode serve :4096
+    |                                      |
+    |  webhook POST /github/webhook  ----->|
+    |  (issues.assigned or                 |
+    |   issue_comment.created)             |
+    |                                      v
+    |                               routes/github.ts
+    |                               1. verify signature (optional)
+    |                               2. parse event + dedup
+    |                               3. get installation token
+    |                                      |
+    |                                      v
+    |                               git clone / fetch repo
+    |                               git worktree add (isolated branch)
+    |                                      |
+    |                                      v
+    |                               bootstrap(worktreeDir, async () => {
+    |                                 Session.create()
+    |                                 SessionPrompt.prompt(issue prompt)
+    |                               })
+    |                                      |
+    |                                      v
+    |                               agent writes files in worktree
+    |                                      |
+    |                                      v
+    |                               git add -A && git commit
+    |                               git push branch
+    |                                      |
+    |  <--- octokit.pulls.create --------- |
+    |  <--- octokit.issues.comment ------- |
+    |                                      |
+    |                               git worktree remove (cleanup)
+```
+
+## Webhook Delivery
+
+GitHub needs to deliver webhooks to `opencode serve`. Options:
+
+```
+Option A: Direct (public IP / VM)
+  GitHub.com ---HTTPS---> opencode serve :4096
+
+Option B: Tunnel (local dev)
+  GitHub.com ---HTTPS---> smee.io/cloudflared/ngrok
+                               |
+                               +---HTTP---> localhost:4096
+
+Option C: Polling (no inbound needed)
+  opencode serve polls GitHub API for new events
+  (not implemented yet)
+```
+
+For the CodexEngineer app (webhook-less app, events: []),
+webhook URL must be configured in GitHub Settings UI:
+  github.com/settings/apps/codexengineer -> Webhook URL
+
+## Events Handled
+
+| Event                          | Action    | Trigger                              |
+|--------------------------------|-----------|--------------------------------------|
+| `issues`                       | assigned  | Issue assigned to bot user           |
+| `issue_comment`                | created   | Comment starts with `/oc ` or `/opencode ` |
+| `pull_request_review_comment`  | created   | (imported but not yet implemented)   |
+
+## Auth Flow
+
+```
+App private key (env: GITHUB_APP_PRIVATE_KEY)
+        |
+        v
+  JWT (RS256, 10min TTL)
+        |
+        v
+  POST /app/installations/{id}/access_tokens
+        |
+        v
+  Installation token (cached, 1hr TTL - 5min buffer)
+        |
+        +---> Octokit (issues, PRs, reactions, comments)
+        +---> git push URL: https://x-access-token:{token}@github.com/...
+```
+
+## File Layout
+
+```
+packages/opencode/src/
+  server/
+    server.ts              # registers .route("/github", GitHubWebhookRoutes())
+    routes/
+      github.ts            # webhook handler (711 lines)
+  cli/cmd/
+    github.ts              # buildIssuePrompt(), extractResponseText() (reused)
+  cli/
+    bootstrap.ts           # bootstrap() for Instance context
+```
+
+## Configuration (env vars)
+
+| Env Var                     | Required | Description                                  |
+|-----------------------------|----------|----------------------------------------------|
+| `GITHUB_APP_ID`             | yes      | GitHub App ID                                |
+| `GITHUB_APP_PRIVATE_KEY`    | yes      | PEM or base64-encoded private key            |
+| `GITHUB_APP_INSTALLATION_ID`| yes      | Installation ID for the target account       |
+| `GITHUB_WEBHOOK_SECRET`     | no       | HMAC secret; skipped if unset                |
+| `GITHUB_WORKSPACES_DIR`     | no       | Where to clone repos (default: ~/.opencode/github-workspaces) |
+| `GITHUB_AGENT_USERNAME`     | no       | Bot login to filter assignments; `*` = any (default: opencode-agent[bot]) |
+| `GITHUB_AGENT_MODEL`        | no       | Model to use, format `provider/model` (e.g. `anthropic/claude-sonnet-4`). Falls back to `MODEL` env var, then config default. |
+
+## Current State vs Design
+
+### What Works
+
+- [x] Route registered at `/github/webhook` in `opencode serve`
+- [x] GitHub App JWT auth (manual RS256)
+- [x] Installation token caching
+- [x] Webhook signature verification (optional)
+- [x] Event parsing and deduplication
+- [x] Repo clone/fetch with token auth
+- [x] Git worktree isolation per run
+- [x] Agent session via `bootstrap()` + `SessionPrompt.prompt()`
+- [x] `commitAll()` + `pushBranch()` + `createPR()` code path
+- [x] Comment posting via Octokit as app bot
+- [x] Worktree cleanup
+- [x] Error handling with GitHub comment on failure
+- [x] Configurable agent username (`GITHUB_AGENT_USERNAME`)
+
+### E2E Test Result (2026-03-30)
+
+Tested with simulated webhook (curl to a 2nd serve instance on :4097):
+
+- Webhook received and accepted: PASS
+- App auth (JWT -> installation token): PASS
+- Repo cloned: PASS
+- Worktree created: PASS
+- Agent session ran: PASS (session ses_2c34c8965ffec0T1fjy52rOvCH)
+- Comment posted as codexengineer[bot]: PASS
+- **Files written by agent: FAIL** (gpt-5-nano returned text, didn't use tools)
+- Branch pushed: SKIPPED (no file changes)
+- PR created: SKIPPED (no file changes)
+
+### Gaps
+
+1. **No real webhook delivery tested** — used `curl` with saved JSON payload
+   to a 2nd serve instance, not a real GitHub webhook to the primary `:4096`.
+   Need to configure webhook URL on GitHub App (via smee.io tunnel or public IP).
+
+2. **Model doesn't write files** — gpt-5-nano described changes as text
+   instead of using Write/Bash tools. Need to test with a capable model
+   (e.g., `github-copilot/claude-sonnet-4`) or configure model selection
+   for webhook-triggered sessions.
+
+3. ~~**No model configuration**~~ — **FIXED**: `GITHUB_AGENT_MODEL` env var
+   supported (format: `provider/model`), falls back to `MODEL`, then config default.
+
+4. **PR review comments not implemented** — `PullRequestReviewCommentEvent`
+   type is imported but no handler exists.
+
+5. ~~**No unit tests for webhook route**~~ — **FIXED**: 33 tests in
+   `test/server/github-webhook.test.ts` covering signature verification,
+   JWT generation, command extraction, config loading, and route-level HTTP behavior.
+
+6. **No `/oc` comment trigger tested** — only `issues.assigned` was tested.
+   `issue_comment` handler exists but hasn't been exercised.
+
+7. **Polling mode not implemented** — only webhook push delivery.
+   CodexEngineer app was designed for polling (events: []).

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -770,13 +770,29 @@ export const GithubRunCommand = cmd({
 
       async function getUserPrompt() {
         const customPrompt = process.env["PROMPT"]
-        // For repo events and issues events, PROMPT is required since there's no comment to extract from
-        if (isRepoEvent || isIssuesEvent) {
+        // For repo events, PROMPT is required since there's no comment/issue to extract from
+        if (isRepoEvent) {
           if (!customPrompt) {
-            const eventType = isRepoEvent ? "scheduled and workflow_dispatch" : "issues"
-            throw new Error(`PROMPT input is required for ${eventType} events`)
+            throw new Error(`PROMPT input is required for scheduled and workflow_dispatch events`)
           }
           return { userPrompt: customPrompt, promptFiles: [] }
+        }
+        // For issues events: auto-extract issue title+body when assigned or opened, otherwise require PROMPT
+        if (isIssuesEvent) {
+          if (customPrompt) {
+            return { userPrompt: customPrompt, promptFiles: [] }
+          }
+          const issuesPayload = payload as IssuesEvent
+          if (issuesPayload.action === "assigned" || issuesPayload.action === "opened") {
+            const issue = issuesPayload.issue
+            const labels = issue.labels?.map((l) => (typeof l === "string" ? l : l.name)).filter(Boolean)
+            const labelText = labels?.length ? `\nLabels: ${labels.join(", ")}` : ""
+            return {
+              userPrompt: `Issue #${issue.number}: ${issue.title}${labelText}\n\n${issue.body || "No description provided."}`,
+              promptFiles: [],
+            }
+          }
+          throw new Error(`PROMPT input is required for issues events with action "${issuesPayload.action}"`)
         }
 
         if (customPrompt) {

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -448,7 +448,7 @@ export const GithubRunCommand = cmd({
         describe: "GitHub personal access token (github_pat_********)",
       }),
   async handler(args) {
-    await bootstrap(process.cwd(), async () => {
+    await bootstrap(process.env.GITHUB_WORKSPACE || process.cwd(), async () => {
       const isMock = args.token || args.event
 
       const context = isMock ? (JSON.parse(args.event!) as Context) : github.context

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -189,6 +189,21 @@ export function formatPromptTooLargeError(files: { filename: string; content: st
   return `PROMPT_TOO_LARGE: The prompt exceeds the model's context limit.${fileDetails}`
 }
 
+/**
+ * Builds a prompt string from a GitHub issue payload.
+ * Used when an issue is assigned or opened to auto-extract the issue context.
+ */
+export function buildIssuePrompt(issue: {
+  number: number
+  title: string
+  body?: string | null
+  labels?: (string | { name?: string })[]
+}): string {
+  const labels = issue.labels?.map((l) => (typeof l === "string" ? l : l.name)).filter(Boolean)
+  const labelText = labels?.length ? `\nLabels: ${labels.join(", ")}` : ""
+  return `Issue #${issue.number}: ${issue.title}${labelText}\n\n${issue.body || "No description provided."}`
+}
+
 export const GithubCommand = cmd({
   command: "github",
   describe: "manage GitHub agent",
@@ -784,11 +799,8 @@ export const GithubRunCommand = cmd({
           }
           const issuesPayload = payload as IssuesEvent
           if (issuesPayload.action === "assigned" || issuesPayload.action === "opened") {
-            const issue = issuesPayload.issue
-            const labels = issue.labels?.map((l) => (typeof l === "string" ? l : l.name)).filter(Boolean)
-            const labelText = labels?.length ? `\nLabels: ${labels.join(", ")}` : ""
             return {
-              userPrompt: `Issue #${issue.number}: ${issue.title}${labelText}\n\n${issue.body || "No description provided."}`,
+              userPrompt: buildIssuePrompt(issuesPayload.issue),
               promptFiles: [],
             }
           }

--- a/packages/opencode/src/server/routes/github.ts
+++ b/packages/opencode/src/server/routes/github.ts
@@ -404,10 +404,13 @@ async function addIssueReaction(
 // Event handlers
 // ---------------------------------------------------------------------------
 
-const AGENT_USERNAME = "opencode-agent[bot]"
+const AGENT_USERNAME =
+  process.env.GITHUB_AGENT_USERNAME || "opencode-agent[bot]"
 const COMMAND_PREFIXES = ["/oc ", "/opencode "]
 
 function isAgentUser(login: string): boolean {
+  // When GITHUB_AGENT_USERNAME is set to "*", accept any assignee
+  if (AGENT_USERNAME === "*") return true
   return login === AGENT_USERNAME || login.endsWith("[bot]")
 }
 

--- a/packages/opencode/src/server/routes/github.ts
+++ b/packages/opencode/src/server/routes/github.ts
@@ -12,7 +12,9 @@ import { Log } from "../../util/log"
 import { lazy } from "../../util/lazy"
 import { bootstrap } from "../../cli/bootstrap"
 import { Session } from "../../session"
+import { MessageID, PartID } from "../../session/schema"
 import { SessionPrompt } from "../../session/prompt"
+import { Provider } from "../../provider/provider"
 import { buildIssuePrompt, extractResponseText } from "../../cli/cmd/github"
 
 const log = Log.create({ service: "github-webhook" })
@@ -21,7 +23,7 @@ const log = Log.create({ service: "github-webhook" })
 // Config — all from env vars
 // ---------------------------------------------------------------------------
 
-interface GitHubWebhookConfig {
+export interface GitHubWebhookConfig {
   appId: number
   privateKey: string
   /** Webhook secret — if empty, signature verification is skipped (useful for local dev) */
@@ -31,7 +33,7 @@ interface GitHubWebhookConfig {
   workspacesDir: string
 }
 
-function loadConfig(): GitHubWebhookConfig | null {
+export function loadConfig(): GitHubWebhookConfig | null {
   const appId = process.env["GITHUB_APP_ID"]
   const privateKey = process.env["GITHUB_APP_PRIVATE_KEY"]
   const installationId = process.env["GITHUB_APP_INSTALLATION_ID"]
@@ -55,7 +57,7 @@ function loadConfig(): GitHubWebhookConfig | null {
 // GitHub App JWT auth (manual RS256 — no @octokit/app dependency)
 // ---------------------------------------------------------------------------
 
-function formatPrivateKey(input: string): string {
+export function formatPrivateKey(input: string): string {
   if (input.includes("BEGIN RSA PRIVATE KEY") || input.includes("BEGIN PRIVATE KEY")) {
     return input.replace(/\\n/g, "\n")
   }
@@ -71,7 +73,7 @@ function base64url(data: Buffer | string): string {
   return buf.toString("base64url")
 }
 
-function createAppJwt(appId: number, privateKey: string): string {
+export function createAppJwt(appId: number, privateKey: string): string {
   const now = Math.floor(Date.now() / 1000)
   const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }))
   const payload = base64url(
@@ -130,7 +132,7 @@ function createOctokit(token: string): Octokit {
 // Webhook signature verification
 // ---------------------------------------------------------------------------
 
-function verifyWebhookSignature(secret: string, payload: string, signature: string | undefined): boolean {
+export function verifyWebhookSignature(secret: string, payload: string, signature: string | undefined): boolean {
   if (!signature) return false
   const expected = "sha256=" + crypto.createHmac("sha256", secret).update(payload).digest("hex")
   try {
@@ -269,6 +271,18 @@ function buildResponseContract(): string {
 // Agent execution
 // ---------------------------------------------------------------------------
 
+function resolveAgentModel(): { providerID: ReturnType<typeof Provider.parseModel>["providerID"]; modelID: ReturnType<typeof Provider.parseModel>["modelID"] } | undefined {
+  const modelStr = process.env["GITHUB_AGENT_MODEL"] || process.env["MODEL"]
+  if (!modelStr) return undefined
+  const { providerID, modelID } = Provider.parseModel(modelStr)
+  if (!providerID.length || !modelID.length) {
+    log.warn("invalid model format, ignoring", { model: modelStr })
+    return undefined
+  }
+  log.info("using explicit model", { providerID, modelID })
+  return { providerID, modelID }
+}
+
 async function runAgent(
   worktreeDir: string,
   prompt: string,
@@ -283,10 +297,14 @@ async function runAgent(
       title,
     })
 
+    const model = resolveAgentModel()
     const result = await SessionPrompt.prompt({
       sessionID: session.id,
+      messageID: MessageID.ascending(),
+      ...(model ? { model } : {}),
       parts: [
         {
+          id: PartID.ascending(),
           type: "text",
           text: prompt + buildResponseContract(),
         },
@@ -408,13 +426,13 @@ const AGENT_USERNAME =
   process.env.GITHUB_AGENT_USERNAME || "opencode-agent[bot]"
 const COMMAND_PREFIXES = ["/oc ", "/opencode "]
 
-function isAgentUser(login: string): boolean {
+export function isAgentUser(login: string): boolean {
   // When GITHUB_AGENT_USERNAME is set to "*", accept any assignee
   if (AGENT_USERNAME === "*") return true
   return login === AGENT_USERNAME || login.endsWith("[bot]")
 }
 
-function extractCommand(body: string): string | null {
+export function extractCommand(body: string): string | null {
   const trimmed = body.trim()
   for (const prefix of COMMAND_PREFIXES) {
     if (trimmed.startsWith(prefix)) {

--- a/packages/opencode/src/server/routes/github.ts
+++ b/packages/opencode/src/server/routes/github.ts
@@ -233,6 +233,23 @@ async function commitAll(cwd: string, message: string): Promise<boolean> {
   }
 }
 
+async function getHeadSha(cwd: string): Promise<string> {
+  return execGit(["rev-parse", "HEAD"], cwd)
+}
+
+async function branchHasNewCommits(cwd: string, baseSha: string): Promise<boolean> {
+  const headSha = await getHeadSha(cwd)
+  return headSha !== baseSha
+}
+
+async function getChangedFiles(cwd: string, baseSha: string): Promise<string[]> {
+  const output = await execGit(["diff", "--name-only", `${baseSha}..HEAD`], cwd)
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
 async function pushBranch(cwd: string, token: string, owner: string, repo: string, branch: string): Promise<void> {
   const remoteUrl = `https://x-access-token:${token}@github.com/${owner}/${repo}.git`
   await execGit(["push", "--force", remoteUrl, `HEAD:${branch}`], cwd)
@@ -258,6 +275,7 @@ function buildResponseContract(): string {
     "Response contract:",
     "- Do NOT use gh CLI, GitHub MCP tools, or GitHub APIs to create/update issues or pull requests.",
     "- Do NOT run `git push` to publish branches to GitHub.",
+    "- Do NOT create git commits yourself. Make local file edits only; OpenCode will commit if needed.",
     "- Do NOT run `git init` or create nested git repositories.",
     "- OpenCode will handle branch publication, PR creation, and posting your response.",
     "- Write your final answer so it can be posted to GitHub as-is.",
@@ -295,6 +313,13 @@ async function runAgent(
   await bootstrap(worktreeDir, async () => {
     const session = await Session.create({
       title,
+      permission: [
+        {
+          permission: "question",
+          action: "deny",
+          pattern: "*",
+        },
+      ],
     })
 
     const model = resolveAgentModel()
@@ -302,6 +327,7 @@ async function runAgent(
       sessionID: session.id,
       messageID: MessageID.ascending(),
       ...(model ? { model } : {}),
+      agent: "build",
       parts: [
         {
           id: PartID.ascending(),
@@ -311,8 +337,14 @@ async function runAgent(
       ],
     })
 
-    responseText = extractResponseText(result.parts)
+    try {
+      responseText = extractResponseText(result.parts)
+    } catch {
+      // Agent may return no text parts (e.g. only tool calls)
+      responseText = null
+    }
     log.info("agent completed", {
+      partTypes: result.parts.map(p => p.type).join(","),
       sessionID: session.id,
       hasText: responseText !== null,
       partsCount: result.parts.length,
@@ -432,6 +464,16 @@ export function isAgentUser(login: string): boolean {
   return login === AGENT_USERNAME || login.endsWith("[bot]")
 }
 
+/** Check if a comment was posted by a bot (used to filter self-replies).
+ *  Unlike isAgentUser, this ignores the wildcard — we never want to
+ *  skip real human comments even when GITHUB_AGENT_USERNAME="*". */
+export function isBotComment(login: string): boolean {
+  if (AGENT_USERNAME !== "*") {
+    return login === AGENT_USERNAME || login.endsWith("[bot]")
+  }
+  return login.endsWith("[bot]")
+}
+
 export function extractCommand(body: string): string | null {
   const trimmed = body.trim()
   for (const prefix of COMMAND_PREFIXES) {
@@ -477,6 +519,8 @@ async function handleIssueAssigned(
   const worktreeDir = await createWorktree(repoDir, config.workspacesDir, owner, repo, branchName, baseBranch)
 
   try {
+    const baseSha = await getHeadSha(worktreeDir)
+
     // Run agent
     const { responseText } = await runAgent(
       worktreeDir,
@@ -485,9 +529,18 @@ async function handleIssueAssigned(
     )
 
     // Commit, push, create PR
-    const hasCommit = await commitAll(worktreeDir, `opencode: issue #${issue.number}`)
+    let hasCommit = await branchHasNewCommits(worktreeDir, baseSha)
+    if (!hasCommit) {
+      hasCommit = await commitAll(worktreeDir, `opencode: issue #${issue.number}`)
+    }
 
     if (hasCommit) {
+      const changedFiles = await getChangedFiles(worktreeDir, baseSha)
+      log.info("detected issue branch changes", {
+        issue: issue.number,
+        changedFiles: changedFiles.join(","),
+        changedFilesCount: changedFiles.length,
+      })
       await pushBranch(worktreeDir, token, owner, repo, branchName)
 
       const existing = await findExistingPR(octokit, owner, repo, branchName)
@@ -555,7 +608,7 @@ async function handleIssueComment(
   const repo = repository.name
 
   // Ignore bot's own comments
-  if (isAgentUser(comment.user.login)) return
+  if (isBotComment(comment.user.login)) return
 
   // Check for command prefix
   const command = extractCommand(comment.body)
@@ -593,15 +646,26 @@ async function handleIssueComment(
   const worktreeDir = await createWorktree(repoDir, config.workspacesDir, owner, repo, branchName, baseBranch)
 
   try {
+    const baseSha = await getHeadSha(worktreeDir)
+
     const { responseText } = await runAgent(
       worktreeDir,
       fullPrompt,
       `${owner}/${repo}#${issue.number} (comment)`,
     )
 
-    const hasCommit = await commitAll(worktreeDir, `opencode: issue #${issue.number}`)
+    let hasCommit = await branchHasNewCommits(worktreeDir, baseSha)
+    if (!hasCommit) {
+      hasCommit = await commitAll(worktreeDir, `opencode: issue #${issue.number}`)
+    }
 
     if (hasCommit) {
+      const changedFiles = await getChangedFiles(worktreeDir, baseSha)
+      log.info("detected comment branch changes", {
+        issue: issue.number,
+        changedFiles: changedFiles.join(","),
+        changedFilesCount: changedFiles.length,
+      })
       await pushBranch(worktreeDir, token, owner, repo, branchName)
 
       const existing = await findExistingPR(octokit, owner, repo, branchName)

--- a/packages/opencode/src/server/routes/github.ts
+++ b/packages/opencode/src/server/routes/github.ts
@@ -1,0 +1,708 @@
+import { Hono } from "hono"
+import { Octokit } from "@octokit/rest"
+import type {
+  IssuesEvent,
+  IssueCommentEvent,
+  PullRequestReviewCommentEvent,
+} from "@octokit/webhooks-types"
+import crypto from "node:crypto"
+import path from "node:path"
+import { mkdir } from "node:fs/promises"
+import { Log } from "../../util/log"
+import { lazy } from "../../util/lazy"
+import { bootstrap } from "../../cli/bootstrap"
+import { Session } from "../../session"
+import { SessionPrompt } from "../../session/prompt"
+import { buildIssuePrompt, extractResponseText } from "../../cli/cmd/github"
+
+const log = Log.create({ service: "github-webhook" })
+
+// ---------------------------------------------------------------------------
+// Config — all from env vars
+// ---------------------------------------------------------------------------
+
+interface GitHubWebhookConfig {
+  appId: number
+  privateKey: string
+  /** Webhook secret — if empty, signature verification is skipped (useful for local dev) */
+  webhookSecret: string | undefined
+  installationId: number
+  /** Base directory for repo worktrees (default: ~/.opencode/github-workspaces) */
+  workspacesDir: string
+}
+
+function loadConfig(): GitHubWebhookConfig | null {
+  const appId = process.env["GITHUB_APP_ID"]
+  const privateKey = process.env["GITHUB_APP_PRIVATE_KEY"]
+  const installationId = process.env["GITHUB_APP_INSTALLATION_ID"]
+
+  if (!appId || !privateKey || !installationId) {
+    return null
+  }
+
+  return {
+    appId: parseInt(appId, 10),
+    privateKey: formatPrivateKey(privateKey),
+    webhookSecret: process.env["GITHUB_WEBHOOK_SECRET"] || undefined,
+    installationId: parseInt(installationId, 10),
+    workspacesDir:
+      process.env["GITHUB_WORKSPACES_DIR"] ??
+      path.join(process.env["HOME"] ?? "/tmp", ".opencode", "github-workspaces"),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GitHub App JWT auth (manual RS256 — no @octokit/app dependency)
+// ---------------------------------------------------------------------------
+
+function formatPrivateKey(input: string): string {
+  if (input.includes("BEGIN RSA PRIVATE KEY") || input.includes("BEGIN PRIVATE KEY")) {
+    return input.replace(/\\n/g, "\n")
+  }
+  const decoded = Buffer.from(input, "base64").toString("utf8")
+  if (decoded.includes("BEGIN RSA PRIVATE KEY") || decoded.includes("BEGIN PRIVATE KEY")) {
+    return decoded
+  }
+  return input.replace(/\\n/g, "\n")
+}
+
+function base64url(data: Buffer | string): string {
+  const buf = typeof data === "string" ? Buffer.from(data) : data
+  return buf.toString("base64url")
+}
+
+function createAppJwt(appId: number, privateKey: string): string {
+  const now = Math.floor(Date.now() / 1000)
+  const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }))
+  const payload = base64url(
+    JSON.stringify({
+      iat: now - 60, // issued 60s ago to account for clock drift
+      exp: now + 10 * 60, // 10 min expiry (max allowed)
+      iss: appId,
+    }),
+  )
+  const unsigned = `${header}.${payload}`
+  const signature = crypto.sign("RSA-SHA256", Buffer.from(unsigned), privateKey)
+  return `${unsigned}.${base64url(signature)}`
+}
+
+/** Token cache: { token, expiresAt } */
+let tokenCache: { token: string; expiresAt: number } | null = null
+
+async function getInstallationToken(config: GitHubWebhookConfig): Promise<string> {
+  // Return cached token if still valid (with 5-min buffer)
+  if (tokenCache && Date.now() < tokenCache.expiresAt - 5 * 60 * 1000) {
+    return tokenCache.token
+  }
+
+  const jwt = createAppJwt(config.appId, config.privateKey)
+  const response = await fetch(
+    `https://api.github.com/app/installations/${config.installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  )
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`Failed to get installation token: ${response.status} ${body}`)
+  }
+
+  const data = (await response.json()) as { token: string; expires_at: string }
+  tokenCache = {
+    token: data.token,
+    expiresAt: new Date(data.expires_at).getTime(),
+  }
+  log.info("installation token refreshed", { expiresAt: data.expires_at })
+  return data.token
+}
+
+function createOctokit(token: string): Octokit {
+  return new Octokit({ auth: token })
+}
+
+// ---------------------------------------------------------------------------
+// Webhook signature verification
+// ---------------------------------------------------------------------------
+
+function verifyWebhookSignature(secret: string, payload: string, signature: string | undefined): boolean {
+  if (!signature) return false
+  const expected = "sha256=" + crypto.createHmac("sha256", secret).update(payload).digest("hex")
+  try {
+    return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature))
+  } catch {
+    return false
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Git operations
+// ---------------------------------------------------------------------------
+
+async function execGit(args: string[], cwd: string): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const stdout = await new Response(proc.stdout).text()
+  const stderr = await new Response(proc.stderr).text()
+  const exitCode = await proc.exited
+  if (exitCode !== 0) {
+    throw new Error(`git ${args.join(" ")} failed (exit ${exitCode}): ${stderr}`)
+  }
+  return stdout.trim()
+}
+
+async function ensureRepo(workspacesDir: string, owner: string, repo: string, token: string): Promise<string> {
+  const repoDir = path.join(workspacesDir, `${owner}__${repo}`)
+  const remoteUrl = `https://x-access-token:${token}@github.com/${owner}/${repo}.git`
+
+  try {
+    // Check if repo dir exists and is a git repo
+    await execGit(["rev-parse", "--git-dir"], repoDir)
+    // Update remote URL (token may have changed)
+    await execGit(["remote", "set-url", "origin", remoteUrl], repoDir)
+    await execGit(["fetch", "origin"], repoDir)
+    log.info("repo fetched", { owner, repo })
+  } catch {
+    // Clone fresh
+    await mkdir(workspacesDir, { recursive: true })
+    await execGit(["clone", remoteUrl, `${owner}__${repo}`], workspacesDir)
+    log.info("repo cloned", { owner, repo })
+  }
+
+  return repoDir
+}
+
+async function getDefaultBranch(repoDir: string): Promise<string> {
+  try {
+    const ref = await execGit(["symbolic-ref", "refs/remotes/origin/HEAD"], repoDir)
+    const parts = ref.split("/")
+    return parts[parts.length - 1] ?? "main"
+  } catch {
+    return "main"
+  }
+}
+
+function generateRunId(): string {
+  return crypto.randomBytes(4).toString("hex")
+}
+
+async function createWorktree(
+  repoDir: string,
+  workspacesDir: string,
+  owner: string,
+  repo: string,
+  branchName: string,
+  baseBranch: string,
+): Promise<string> {
+  const worktreeDir = path.join(workspacesDir, `${owner}__${repo}`, ".worktrees", branchName)
+
+  // Clean up if exists
+  try {
+    await execGit(["worktree", "remove", "--force", worktreeDir], repoDir)
+  } catch {
+    // doesn't exist, fine
+  }
+
+  await mkdir(path.dirname(worktreeDir), { recursive: true })
+  await execGit(["worktree", "add", "-B", branchName, worktreeDir, `origin/${baseBranch}`], repoDir)
+  log.info("worktree created", { branchName, worktreeDir })
+  return worktreeDir
+}
+
+async function commitAll(cwd: string, message: string): Promise<boolean> {
+  await execGit(["add", "-A"], cwd)
+  try {
+    // Check if there are staged changes
+    await execGit(["diff", "--cached", "--quiet"], cwd)
+    // If no error, there's nothing to commit
+    return false
+  } catch {
+    // There are staged changes, commit them
+    await execGit(["commit", "-m", message], cwd)
+    return true
+  }
+}
+
+async function pushBranch(cwd: string, token: string, owner: string, repo: string, branch: string): Promise<void> {
+  const remoteUrl = `https://x-access-token:${token}@github.com/${owner}/${repo}.git`
+  await execGit(["push", "--force", remoteUrl, `HEAD:${branch}`], cwd)
+  log.info("branch pushed", { owner, repo, branch })
+}
+
+async function cleanupWorktree(repoDir: string, worktreeDir: string): Promise<void> {
+  try {
+    await execGit(["worktree", "remove", "--force", worktreeDir], repoDir)
+    log.info("worktree cleaned up", { worktreeDir })
+  } catch (err) {
+    log.warn("worktree cleanup failed", { worktreeDir, error: String(err) })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Response contract — instructs the agent NOT to push/PR/use gh CLI
+// ---------------------------------------------------------------------------
+
+function buildResponseContract(): string {
+  return [
+    "",
+    "Response contract:",
+    "- Do NOT use gh CLI, GitHub MCP tools, or GitHub APIs to create/update issues or pull requests.",
+    "- Do NOT run `git push` to publish branches to GitHub.",
+    "- Do NOT run `git init` or create nested git repositories.",
+    "- OpenCode will handle branch publication, PR creation, and posting your response.",
+    "- Write your final answer so it can be posted to GitHub as-is.",
+    "- Local file edits and local git commits are fine.",
+    "- If code changes are ready for review, describe the changes made.",
+    "- If you ran important commands or tests, include results with pass/fail status.",
+  ].join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// Agent execution
+// ---------------------------------------------------------------------------
+
+async function runAgent(
+  worktreeDir: string,
+  prompt: string,
+  title: string,
+): Promise<{ responseText: string | null }> {
+  log.info("running agent", { worktreeDir, title, promptLength: prompt.length })
+
+  let responseText: string | null = null
+
+  await bootstrap(worktreeDir, async () => {
+    const session = await Session.create({
+      title,
+    })
+
+    const result = await SessionPrompt.prompt({
+      sessionID: session.id,
+      parts: [
+        {
+          type: "text",
+          text: prompt + buildResponseContract(),
+        },
+      ],
+    })
+
+    responseText = extractResponseText(result.parts)
+    log.info("agent completed", {
+      sessionID: session.id,
+      hasText: responseText !== null,
+      partsCount: result.parts.length,
+    })
+  })
+
+  return { responseText }
+}
+
+// ---------------------------------------------------------------------------
+// PR creation & GitHub commenting
+// ---------------------------------------------------------------------------
+
+async function findExistingPR(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  headBranch: string,
+): Promise<{ number: number; html_url: string } | null> {
+  const { data } = await octokit.pulls.list({
+    owner,
+    repo,
+    state: "open",
+    head: `${owner}:${headBranch}`,
+    per_page: 1,
+  })
+  const pr = data[0]
+  if (!pr) return null
+  return { number: pr.number, html_url: pr.html_url }
+}
+
+async function createPR(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  head: string,
+  base: string,
+  title: string,
+  body: string,
+  issueNumber?: number,
+): Promise<{ number: number; html_url: string }> {
+  const { data } = await octokit.pulls.create({
+    owner,
+    repo,
+    head,
+    base,
+    title,
+    body,
+  })
+  return { number: data.number, html_url: data.html_url }
+}
+
+async function postComment(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  body: string,
+): Promise<void> {
+  await octokit.issues.createComment({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body,
+  })
+}
+
+async function addReaction(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  commentId: number,
+  reaction: "+1" | "eyes" | "rocket",
+): Promise<void> {
+  try {
+    await octokit.reactions.createForIssueComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      content: reaction,
+    })
+  } catch {
+    // non-critical
+  }
+}
+
+async function addIssueReaction(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  reaction: "+1" | "eyes" | "rocket",
+): Promise<void> {
+  try {
+    await octokit.reactions.createForIssue({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      content: reaction,
+    })
+  } catch {
+    // non-critical
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Event handlers
+// ---------------------------------------------------------------------------
+
+const AGENT_USERNAME = "opencode-agent[bot]"
+const COMMAND_PREFIXES = ["/oc ", "/opencode "]
+
+function isAgentUser(login: string): boolean {
+  return login === AGENT_USERNAME || login.endsWith("[bot]")
+}
+
+function extractCommand(body: string): string | null {
+  const trimmed = body.trim()
+  for (const prefix of COMMAND_PREFIXES) {
+    if (trimmed.startsWith(prefix)) {
+      return trimmed.slice(prefix.length).trim()
+    }
+  }
+  // If entire body is a command without prefix, it's treated as a direct issue prompt
+  return null
+}
+
+async function handleIssueAssigned(
+  event: IssuesEvent,
+  config: GitHubWebhookConfig,
+): Promise<void> {
+  const { issue, repository } = event
+  const owner = repository.owner.login
+  const repo = repository.name
+
+  // Only handle assignment to the bot
+  if (event.action !== "assigned") return
+  const assignee = (event as any).assignee?.login
+  if (assignee && !isAgentUser(assignee)) {
+    log.info("issue assigned to non-agent user, skipping", { assignee })
+    return
+  }
+
+  log.info("handling issue assignment", { owner, repo, issue: issue.number })
+
+  const token = await getInstallationToken(config)
+  const octokit = createOctokit(token)
+
+  // React to signal we're working on it
+  await addIssueReaction(octokit, owner, repo, issue.number, "eyes")
+
+  const prompt = buildIssuePrompt(issue)
+  const runId = generateRunId()
+  const branchName = `opencode/${issue.number}-${runId}`
+
+  // Prepare repo + worktree
+  const repoDir = await ensureRepo(config.workspacesDir, owner, repo, token)
+  const baseBranch = await getDefaultBranch(repoDir)
+  const worktreeDir = await createWorktree(repoDir, config.workspacesDir, owner, repo, branchName, baseBranch)
+
+  try {
+    // Run agent
+    const { responseText } = await runAgent(
+      worktreeDir,
+      prompt,
+      `${owner}/${repo}#${issue.number}`,
+    )
+
+    // Commit, push, create PR
+    const hasCommit = await commitAll(worktreeDir, `opencode: issue #${issue.number}`)
+
+    if (hasCommit) {
+      await pushBranch(worktreeDir, token, owner, repo, branchName)
+
+      const existing = await findExistingPR(octokit, owner, repo, branchName)
+      if (!existing) {
+        const prBody = [
+          `Closes #${issue.number}`,
+          "",
+          responseText ?? "Changes applied by OpenCode agent.",
+        ].join("\n")
+
+        const pr = await createPR(
+          octokit,
+          owner,
+          repo,
+          branchName,
+          baseBranch,
+          `opencode: ${issue.title}`,
+          prBody,
+          issue.number,
+        )
+
+        await postComment(
+          octokit,
+          owner,
+          repo,
+          issue.number,
+          `Pull request created: ${pr.html_url}`,
+        )
+        log.info("PR created", { pr: pr.html_url })
+      } else {
+        log.info("PR already exists", { pr: existing.html_url })
+      }
+    } else {
+      // No code changes — just post the response as a comment
+      const comment = responseText ?? "No code changes were needed."
+      await postComment(octokit, owner, repo, issue.number, comment)
+      log.info("no code changes, posted comment")
+    }
+  } catch (err) {
+    log.error("issue handler failed", { error: err })
+    try {
+      await postComment(
+        octokit,
+        owner,
+        repo,
+        issue.number,
+        `OpenCode agent encountered an error:\n\`\`\`\n${err instanceof Error ? err.message : String(err)}\n\`\`\``,
+      )
+    } catch {
+      // best effort
+    }
+  } finally {
+    await cleanupWorktree(repoDir, worktreeDir)
+  }
+}
+
+async function handleIssueComment(
+  event: IssueCommentEvent,
+  config: GitHubWebhookConfig,
+): Promise<void> {
+  if (event.action !== "created") return
+
+  const { comment, issue, repository } = event
+  const owner = repository.owner.login
+  const repo = repository.name
+
+  // Ignore bot's own comments
+  if (isAgentUser(comment.user.login)) return
+
+  // Check for command prefix
+  const command = extractCommand(comment.body)
+  if (!command) {
+    log.info("comment without command prefix, skipping", {
+      owner,
+      repo,
+      issue: issue.number,
+    })
+    return
+  }
+
+  log.info("handling issue comment command", {
+    owner,
+    repo,
+    issue: issue.number,
+    command: command.slice(0, 100),
+  })
+
+  const token = await getInstallationToken(config)
+  const octokit = createOctokit(token)
+
+  // React to acknowledge
+  await addReaction(octokit, owner, repo, comment.id, "eyes")
+
+  // Build prompt: issue context + command
+  const issuePrompt = buildIssuePrompt(issue)
+  const fullPrompt = `${issuePrompt}\n\n---\n\nUser command: ${command}`
+
+  const runId = generateRunId()
+  const branchName = `opencode/${issue.number}-${runId}`
+
+  const repoDir = await ensureRepo(config.workspacesDir, owner, repo, token)
+  const baseBranch = await getDefaultBranch(repoDir)
+  const worktreeDir = await createWorktree(repoDir, config.workspacesDir, owner, repo, branchName, baseBranch)
+
+  try {
+    const { responseText } = await runAgent(
+      worktreeDir,
+      fullPrompt,
+      `${owner}/${repo}#${issue.number} (comment)`,
+    )
+
+    const hasCommit = await commitAll(worktreeDir, `opencode: issue #${issue.number}`)
+
+    if (hasCommit) {
+      await pushBranch(worktreeDir, token, owner, repo, branchName)
+
+      const existing = await findExistingPR(octokit, owner, repo, branchName)
+      if (!existing) {
+        const prBody = [
+          `Related to #${issue.number}`,
+          "",
+          responseText ?? "Changes applied by OpenCode agent.",
+        ].join("\n")
+
+        const pr = await createPR(
+          octokit,
+          owner,
+          repo,
+          branchName,
+          baseBranch,
+          `opencode: ${issue.title}`,
+          prBody,
+          issue.number,
+        )
+
+        await postComment(
+          octokit,
+          owner,
+          repo,
+          issue.number,
+          `Pull request created: ${pr.html_url}`,
+        )
+        log.info("PR created from comment", { pr: pr.html_url })
+      }
+    } else {
+      const response = responseText ?? "No code changes were needed."
+      await postComment(octokit, owner, repo, issue.number, response)
+      log.info("no code changes from comment, posted response")
+    }
+
+    // Add completion reaction
+    await addReaction(octokit, owner, repo, comment.id, "rocket")
+  } catch (err) {
+    log.error("comment handler failed", { error: err })
+    try {
+      await postComment(
+        octokit,
+        owner,
+        repo,
+        issue.number,
+        `OpenCode agent encountered an error:\n\`\`\`\n${err instanceof Error ? err.message : String(err)}\n\`\`\``,
+      )
+    } catch {
+      // best effort
+    }
+  } finally {
+    await cleanupWorktree(repoDir, worktreeDir)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Active runs tracking (prevent duplicate processing)
+// ---------------------------------------------------------------------------
+
+const activeRuns = new Set<string>()
+
+function runKey(owner: string, repo: string, issueNumber: number, action: string): string {
+  return `${owner}/${repo}#${issueNumber}:${action}`
+}
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+export const GitHubWebhookRoutes = lazy(
+  () =>
+    new Hono().post("/webhook", async (c) => {
+      const config = loadConfig()
+      if (!config) {
+        return c.json({ error: "GitHub webhook not configured" }, 503)
+      }
+
+      // Verify signature (if secret configured)
+      const body = await c.req.text()
+      if (config.webhookSecret) {
+        const signature = c.req.header("x-hub-signature-256")
+        if (!verifyWebhookSignature(config.webhookSecret, body, signature)) {
+          log.warn("webhook signature verification failed")
+          return c.json({ error: "Invalid signature" }, 401)
+        }
+      }
+
+      const event = c.req.header("x-github-event")
+      const delivery = c.req.header("x-github-delivery")
+      log.info("webhook received", { event, delivery })
+
+      const payload = JSON.parse(body)
+
+      // Deduplication
+      const owner = payload.repository?.owner?.login
+      const repo = payload.repository?.name
+      const issueNumber = payload.issue?.number
+      if (owner && repo && issueNumber) {
+        const key = runKey(owner, repo, issueNumber, event ?? "unknown")
+        if (activeRuns.has(key)) {
+          log.info("duplicate run, skipping", { key })
+          return c.json({ status: "skipped", reason: "already processing" })
+        }
+        activeRuns.add(key)
+
+        // Process async — return 200 immediately
+        void (async () => {
+          try {
+            if (event === "issues") {
+              await handleIssueAssigned(payload as IssuesEvent, config)
+            } else if (event === "issue_comment") {
+              await handleIssueComment(payload as IssueCommentEvent, config)
+            }
+          } catch (err) {
+            log.error("webhook handler error", { event, error: err })
+          } finally {
+            activeRuns.delete(key)
+          }
+        })()
+      }
+
+      return c.json({ status: "accepted", event, delivery })
+    }),
+)

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -42,6 +42,7 @@ import { QuestionRoutes } from "./routes/question"
 import { PermissionRoutes } from "./routes/permission"
 import { GlobalRoutes } from "./routes/global"
 import { TtsRoutes } from "./routes/tts"
+import { GitHubWebhookRoutes } from "./routes/github"
 import { MDNS } from "./mdns"
 import { lazy } from "@/util/lazy"
 
@@ -145,6 +146,7 @@ export namespace Server {
       )
       .route("/global", GlobalRoutes())
       .route("/tts", TtsRoutes())
+      .route("/github", GitHubWebhookRoutes())
       .put(
         "/auth/:providerID",
         describeRoute({

--- a/packages/opencode/test/cli/github-action.test.ts
+++ b/packages/opencode/test/cli/github-action.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test"
-import { extractResponseText, formatPromptTooLargeError } from "../../src/cli/cmd/github"
+import { extractResponseText, formatPromptTooLargeError, buildIssuePrompt } from "../../src/cli/cmd/github"
 import type { MessageV2 } from "../../src/session/message-v2"
 import { SessionID, MessageID, PartID } from "../../src/session/schema"
 
@@ -194,5 +194,114 @@ describe("formatPromptTooLargeError", () => {
     expect(result).toInclude("img1.png (3 KB)")
     expect(result).toInclude("img2.jpg (6 KB)")
     expect(result).toInclude("img3.gif (9 KB)")
+  })
+})
+
+describe("buildIssuePrompt", () => {
+  test("builds prompt with title and body", () => {
+    const result = buildIssuePrompt({
+      number: 42,
+      title: "Fix login bug",
+      body: "Users cannot log in with SSO.",
+    })
+    expect(result).toBe("Issue #42: Fix login bug\n\nUsers cannot log in with SSO.")
+  })
+
+  test("uses fallback when body is null", () => {
+    const result = buildIssuePrompt({
+      number: 1,
+      title: "No body issue",
+      body: null,
+    })
+    expect(result).toInclude("No description provided.")
+    expect(result).toStartWith("Issue #1: No body issue")
+  })
+
+  test("uses fallback when body is undefined", () => {
+    const result = buildIssuePrompt({
+      number: 1,
+      title: "No body issue",
+    })
+    expect(result).toInclude("No description provided.")
+  })
+
+  test("uses fallback when body is empty string", () => {
+    const result = buildIssuePrompt({
+      number: 5,
+      title: "Empty body",
+      body: "",
+    })
+    expect(result).toInclude("No description provided.")
+  })
+
+  test("includes labels from string array", () => {
+    const result = buildIssuePrompt({
+      number: 10,
+      title: "Labeled issue",
+      body: "Some body",
+      labels: ["bug", "priority"],
+    })
+    expect(result).toInclude("Labels: bug, priority")
+  })
+
+  test("includes labels from object array", () => {
+    const result = buildIssuePrompt({
+      number: 10,
+      title: "Labeled issue",
+      body: "Some body",
+      labels: [{ name: "enhancement" }, { name: "help wanted" }],
+    })
+    expect(result).toInclude("Labels: enhancement, help wanted")
+  })
+
+  test("handles mixed label types (string and object)", () => {
+    const result = buildIssuePrompt({
+      number: 10,
+      title: "Mixed labels",
+      body: "Body",
+      labels: ["bug", { name: "urgent" }],
+    })
+    expect(result).toInclude("Labels: bug, urgent")
+  })
+
+  test("omits labels line when labels array is empty", () => {
+    const result = buildIssuePrompt({
+      number: 3,
+      title: "No labels",
+      body: "Body text",
+      labels: [],
+    })
+    expect(result).not.toInclude("Labels:")
+    expect(result).toBe("Issue #3: No labels\n\nBody text")
+  })
+
+  test("omits labels line when labels is undefined", () => {
+    const result = buildIssuePrompt({
+      number: 3,
+      title: "No labels",
+      body: "Body text",
+    })
+    expect(result).not.toInclude("Labels:")
+  })
+
+  test("filters out labels with missing name", () => {
+    const result = buildIssuePrompt({
+      number: 7,
+      title: "Partial labels",
+      body: "Body",
+      labels: [{ name: "valid" }, { name: undefined } as any, { name: "" }],
+    })
+    expect(result).toInclude("Labels: valid")
+  })
+
+  test("preserves markdown formatting in body", () => {
+    const body = "## Steps to reproduce\n\n1. Open the app\n2. Click login\n\n```js\nconsole.log('test')\n```"
+    const result = buildIssuePrompt({
+      number: 99,
+      title: "Markdown body",
+      body,
+    })
+    expect(result).toInclude("## Steps to reproduce")
+    expect(result).toInclude("```js")
   })
 })

--- a/packages/opencode/test/server/github-webhook.test.ts
+++ b/packages/opencode/test/server/github-webhook.test.ts
@@ -1,0 +1,452 @@
+import { test, expect, describe, beforeAll, afterAll } from "bun:test"
+import crypto from "node:crypto"
+import { Hono } from "hono"
+import {
+  verifyWebhookSignature,
+  formatPrivateKey,
+  extractCommand,
+  isAgentUser,
+  createAppJwt,
+  loadConfig,
+  GitHubWebhookRoutes,
+} from "../../src/server/routes/github"
+
+// ---------------------------------------------------------------------------
+// verifyWebhookSignature
+// ---------------------------------------------------------------------------
+
+describe("verifyWebhookSignature", () => {
+  const secret = "test-secret-123"
+  const payload = '{"action":"opened"}'
+
+  function sign(s: string, p: string): string {
+    return "sha256=" + crypto.createHmac("sha256", s).update(p).digest("hex")
+  }
+
+  test("returns true for valid signature", () => {
+    const sig = sign(secret, payload)
+    expect(verifyWebhookSignature(secret, payload, sig)).toBe(true)
+  })
+
+  test("returns false for invalid signature", () => {
+    expect(verifyWebhookSignature(secret, payload, "sha256=deadbeef")).toBe(false)
+  })
+
+  test("returns false when signature is undefined", () => {
+    expect(verifyWebhookSignature(secret, payload, undefined)).toBe(false)
+  })
+
+  test("returns false when signature is empty string", () => {
+    expect(verifyWebhookSignature(secret, payload, "")).toBe(false)
+  })
+
+  test("returns false for wrong secret", () => {
+    const sig = sign("wrong-secret", payload)
+    expect(verifyWebhookSignature(secret, payload, sig)).toBe(false)
+  })
+
+  test("returns false for tampered payload", () => {
+    const sig = sign(secret, payload)
+    expect(verifyWebhookSignature(secret, '{"action":"closed"}', sig)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatPrivateKey
+// ---------------------------------------------------------------------------
+
+describe("formatPrivateKey", () => {
+  const PEM_HEADER = "-----BEGIN RSA PRIVATE KEY-----"
+  const PEM_FOOTER = "-----END RSA PRIVATE KEY-----"
+  const BODY = "MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn" // truncated for test
+
+  test("returns PEM as-is when it contains header", () => {
+    const pem = `${PEM_HEADER}\n${BODY}\n${PEM_FOOTER}`
+    expect(formatPrivateKey(pem)).toBe(pem)
+  })
+
+  test("handles escaped newlines in PEM", () => {
+    const escaped = `${PEM_HEADER}\\n${BODY}\\n${PEM_FOOTER}`
+    const result = formatPrivateKey(escaped)
+    expect(result).toContain("\n")
+    expect(result).not.toContain("\\n")
+  })
+
+  test("decodes base64-encoded PEM", () => {
+    const pem = `${PEM_HEADER}\n${BODY}\n${PEM_FOOTER}`
+    const b64 = Buffer.from(pem).toString("base64")
+    const result = formatPrivateKey(b64)
+    expect(result).toBe(pem)
+  })
+
+  test("handles PKCS8 format (BEGIN PRIVATE KEY)", () => {
+    const pem = `-----BEGIN PRIVATE KEY-----\n${BODY}\n-----END PRIVATE KEY-----`
+    expect(formatPrivateKey(pem)).toBe(pem)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractCommand
+// ---------------------------------------------------------------------------
+
+describe("extractCommand", () => {
+  test("extracts /oc command", () => {
+    expect(extractCommand("/oc fix the bug")).toBe("fix the bug")
+  })
+
+  test("extracts /opencode command", () => {
+    expect(extractCommand("/opencode refactor this")).toBe("refactor this")
+  })
+
+  test("trims whitespace around body", () => {
+    expect(extractCommand("  /oc do something  ")).toBe("do something")
+  })
+
+  test("returns null for body without command prefix", () => {
+    expect(extractCommand("This is a normal comment")).toBeNull()
+  })
+
+  test("returns null for empty string", () => {
+    expect(extractCommand("")).toBeNull()
+  })
+
+  test("returns null for /oc without space (not a valid prefix)", () => {
+    // "/oc " (with space) is the prefix, "/ocfoo" should not match
+    expect(extractCommand("/ocfoo")).toBeNull()
+  })
+
+  test("handles multi-line commands", () => {
+    expect(extractCommand("/oc fix this\nand that too")).toBe("fix this\nand that too")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isAgentUser
+// ---------------------------------------------------------------------------
+
+describe("isAgentUser", () => {
+  // Save and restore GITHUB_AGENT_USERNAME
+  const originalUsername = process.env.GITHUB_AGENT_USERNAME
+
+  afterAll(() => {
+    if (originalUsername !== undefined) {
+      process.env.GITHUB_AGENT_USERNAME = originalUsername
+    } else {
+      delete process.env.GITHUB_AGENT_USERNAME
+    }
+  })
+
+  test("matches bot usernames (ending with [bot])", () => {
+    // Default AGENT_USERNAME is read at module load time, but [bot] suffix check is always true
+    expect(isAgentUser("some-app[bot]")).toBe(true)
+  })
+
+  test("does not match regular users by default", () => {
+    // This depends on AGENT_USERNAME not being "*" or matching the login
+    // With default config, regular users should not match unless AGENT_USERNAME is "*"
+    const agentUsername = process.env.GITHUB_AGENT_USERNAME || "opencode-agent[bot]"
+    if (agentUsername === "*") {
+      expect(isAgentUser("regularuser")).toBe(true) // * matches all
+    } else {
+      expect(isAgentUser("regularuser")).toBe(false)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createAppJwt
+// ---------------------------------------------------------------------------
+
+describe("createAppJwt", () => {
+  // Generate a test RSA key pair
+  let testPrivateKey: string
+
+  beforeAll(() => {
+    const { privateKey } = crypto.generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: "spki", format: "pem" },
+      privateKeyEncoding: { type: "pkcs1", format: "pem" },
+    })
+    testPrivateKey = privateKey
+  })
+
+  test("returns a valid JWT with three parts", () => {
+    const jwt = createAppJwt(12345, testPrivateKey)
+    const parts = jwt.split(".")
+    expect(parts.length).toBe(3)
+  })
+
+  test("JWT header specifies RS256", () => {
+    const jwt = createAppJwt(12345, testPrivateKey)
+    const header = JSON.parse(Buffer.from(jwt.split(".")[0], "base64url").toString())
+    expect(header.alg).toBe("RS256")
+    expect(header.typ).toBe("JWT")
+  })
+
+  test("JWT payload contains correct app ID as issuer", () => {
+    const jwt = createAppJwt(99999, testPrivateKey)
+    const payload = JSON.parse(Buffer.from(jwt.split(".")[1], "base64url").toString())
+    expect(payload.iss).toBe(99999)
+  })
+
+  test("JWT payload has valid timestamps", () => {
+    const before = Math.floor(Date.now() / 1000)
+    const jwt = createAppJwt(12345, testPrivateKey)
+    const after = Math.floor(Date.now() / 1000)
+
+    const payload = JSON.parse(Buffer.from(jwt.split(".")[1], "base64url").toString())
+    // iat should be ~60s before now
+    expect(payload.iat).toBeGreaterThanOrEqual(before - 61)
+    expect(payload.iat).toBeLessThanOrEqual(after - 59)
+    // exp should be ~10 min from now
+    expect(payload.exp).toBeGreaterThanOrEqual(before + 9 * 60)
+    expect(payload.exp).toBeLessThanOrEqual(after + 11 * 60)
+  })
+
+  test("JWT signature is verifiable", () => {
+    const { privateKey, publicKey } = crypto.generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: "spki", format: "pem" },
+      privateKeyEncoding: { type: "pkcs1", format: "pem" },
+    })
+
+    const jwt = createAppJwt(12345, privateKey)
+    const [h, p, sig] = jwt.split(".")
+    const unsigned = `${h}.${p}`
+    const isValid = crypto.verify("RSA-SHA256", Buffer.from(unsigned), publicKey, Buffer.from(sig, "base64url"))
+    expect(isValid).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadConfig
+// ---------------------------------------------------------------------------
+
+describe("loadConfig", () => {
+  const savedEnv: Record<string, string | undefined> = {}
+  const envKeys = [
+    "GITHUB_APP_ID",
+    "GITHUB_APP_PRIVATE_KEY",
+    "GITHUB_APP_INSTALLATION_ID",
+    "GITHUB_WEBHOOK_SECRET",
+    "GITHUB_WORKSPACES_DIR",
+  ]
+
+  beforeAll(() => {
+    for (const key of envKeys) {
+      savedEnv[key] = process.env[key]
+    }
+  })
+
+  afterAll(() => {
+    for (const key of envKeys) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key]
+      } else {
+        delete process.env[key]
+      }
+    }
+  })
+
+  test("returns null when GITHUB_APP_ID is missing", () => {
+    delete process.env.GITHUB_APP_ID
+    process.env.GITHUB_APP_PRIVATE_KEY = "test-key"
+    process.env.GITHUB_APP_INSTALLATION_ID = "123"
+    expect(loadConfig()).toBeNull()
+  })
+
+  test("returns null when GITHUB_APP_PRIVATE_KEY is missing", () => {
+    process.env.GITHUB_APP_ID = "456"
+    delete process.env.GITHUB_APP_PRIVATE_KEY
+    process.env.GITHUB_APP_INSTALLATION_ID = "123"
+    expect(loadConfig()).toBeNull()
+  })
+
+  test("returns null when GITHUB_APP_INSTALLATION_ID is missing", () => {
+    process.env.GITHUB_APP_ID = "456"
+    process.env.GITHUB_APP_PRIVATE_KEY = "test-key"
+    delete process.env.GITHUB_APP_INSTALLATION_ID
+    expect(loadConfig()).toBeNull()
+  })
+
+  test("returns config when all required env vars are set", () => {
+    process.env.GITHUB_APP_ID = "456"
+    process.env.GITHUB_APP_PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
+    process.env.GITHUB_APP_INSTALLATION_ID = "789"
+    delete process.env.GITHUB_WEBHOOK_SECRET
+    delete process.env.GITHUB_WORKSPACES_DIR
+
+    const config = loadConfig()
+    expect(config).not.toBeNull()
+    expect(config!.appId).toBe(456)
+    expect(config!.installationId).toBe(789)
+    expect(config!.webhookSecret).toBeUndefined()
+    expect(config!.workspacesDir).toContain("github-workspaces")
+  })
+
+  test("uses custom workspaces dir when set", () => {
+    process.env.GITHUB_APP_ID = "1"
+    process.env.GITHUB_APP_PRIVATE_KEY = "key"
+    process.env.GITHUB_APP_INSTALLATION_ID = "2"
+    process.env.GITHUB_WORKSPACES_DIR = "/custom/path"
+
+    const config = loadConfig()
+    expect(config!.workspacesDir).toBe("/custom/path")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Route handler (HTTP-level tests)
+// ---------------------------------------------------------------------------
+
+describe("webhook route handler", () => {
+  test("returns 503 when config is not set", async () => {
+    // Save env
+    const saved = {
+      GITHUB_APP_ID: process.env.GITHUB_APP_ID,
+      GITHUB_APP_PRIVATE_KEY: process.env.GITHUB_APP_PRIVATE_KEY,
+      GITHUB_APP_INSTALLATION_ID: process.env.GITHUB_APP_INSTALLATION_ID,
+    }
+
+    // Clear env to ensure loadConfig returns null
+    delete process.env.GITHUB_APP_ID
+    delete process.env.GITHUB_APP_PRIVATE_KEY
+    delete process.env.GITHUB_APP_INSTALLATION_ID
+
+    try {
+      const app = new Hono().route("/github", GitHubWebhookRoutes())
+      const res = await app.request("/github/webhook", {
+        method: "POST",
+        body: JSON.stringify({ action: "opened" }),
+        headers: { "Content-Type": "application/json" },
+      })
+      expect(res.status).toBe(503)
+      const json = (await res.json()) as { error: string }
+      expect(json.error).toContain("not configured")
+    } finally {
+      // Restore env
+      for (const [k, v] of Object.entries(saved)) {
+        if (v !== undefined) process.env[k] = v
+        else delete process.env[k]
+      }
+    }
+  })
+
+  test("returns 401 when signature verification fails", async () => {
+    const saved = {
+      GITHUB_APP_ID: process.env.GITHUB_APP_ID,
+      GITHUB_APP_PRIVATE_KEY: process.env.GITHUB_APP_PRIVATE_KEY,
+      GITHUB_APP_INSTALLATION_ID: process.env.GITHUB_APP_INSTALLATION_ID,
+      GITHUB_WEBHOOK_SECRET: process.env.GITHUB_WEBHOOK_SECRET,
+    }
+
+    process.env.GITHUB_APP_ID = "1"
+    process.env.GITHUB_APP_PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
+    process.env.GITHUB_APP_INSTALLATION_ID = "2"
+    process.env.GITHUB_WEBHOOK_SECRET = "my-secret"
+
+    try {
+      const app = new Hono().route("/github", GitHubWebhookRoutes())
+      const res = await app.request("/github/webhook", {
+        method: "POST",
+        body: JSON.stringify({ action: "opened" }),
+        headers: {
+          "Content-Type": "application/json",
+          "x-hub-signature-256": "sha256=invalidsignature",
+          "x-github-event": "issues",
+        },
+      })
+      expect(res.status).toBe(401)
+    } finally {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v !== undefined) process.env[k] = v
+        else delete process.env[k]
+      }
+    }
+  })
+
+  test("accepts webhook without secret when GITHUB_WEBHOOK_SECRET is not set", async () => {
+    const saved = {
+      GITHUB_APP_ID: process.env.GITHUB_APP_ID,
+      GITHUB_APP_PRIVATE_KEY: process.env.GITHUB_APP_PRIVATE_KEY,
+      GITHUB_APP_INSTALLATION_ID: process.env.GITHUB_APP_INSTALLATION_ID,
+      GITHUB_WEBHOOK_SECRET: process.env.GITHUB_WEBHOOK_SECRET,
+    }
+
+    process.env.GITHUB_APP_ID = "1"
+    process.env.GITHUB_APP_PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
+    process.env.GITHUB_APP_INSTALLATION_ID = "2"
+    delete process.env.GITHUB_WEBHOOK_SECRET
+
+    try {
+      const app = new Hono().route("/github", GitHubWebhookRoutes())
+      const payload = JSON.stringify({
+        action: "opened",
+        repository: { owner: { login: "testowner" }, name: "testrepo" },
+        issue: { number: 1 },
+      })
+      const res = await app.request("/github/webhook", {
+        method: "POST",
+        body: payload,
+        headers: {
+          "Content-Type": "application/json",
+          "x-github-event": "issues",
+          "x-github-delivery": "test-delivery-123",
+        },
+      })
+      expect(res.status).toBe(200)
+      const json = (await res.json()) as { status: string; event: string }
+      expect(json.status).toBe("accepted")
+      expect(json.event).toBe("issues")
+    } finally {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v !== undefined) process.env[k] = v
+        else delete process.env[k]
+      }
+    }
+  })
+
+  test("passes signature verification with valid HMAC", async () => {
+    const saved = {
+      GITHUB_APP_ID: process.env.GITHUB_APP_ID,
+      GITHUB_APP_PRIVATE_KEY: process.env.GITHUB_APP_PRIVATE_KEY,
+      GITHUB_APP_INSTALLATION_ID: process.env.GITHUB_APP_INSTALLATION_ID,
+      GITHUB_WEBHOOK_SECRET: process.env.GITHUB_WEBHOOK_SECRET,
+    }
+
+    const secret = "webhook-secret-for-test"
+    process.env.GITHUB_APP_ID = "1"
+    process.env.GITHUB_APP_PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
+    process.env.GITHUB_APP_INSTALLATION_ID = "2"
+    process.env.GITHUB_WEBHOOK_SECRET = secret
+
+    try {
+      const app = new Hono().route("/github", GitHubWebhookRoutes())
+      const payload = JSON.stringify({
+        action: "opened",
+        repository: { owner: { login: "testowner" }, name: "testrepo" },
+        issue: { number: 42 },
+      })
+      const signature =
+        "sha256=" + crypto.createHmac("sha256", secret).update(payload).digest("hex")
+      const res = await app.request("/github/webhook", {
+        method: "POST",
+        body: payload,
+        headers: {
+          "Content-Type": "application/json",
+          "x-github-event": "issues",
+          "x-github-delivery": "test-delivery-456",
+          "x-hub-signature-256": signature,
+        },
+      })
+      expect(res.status).toBe(200)
+      const json = (await res.json()) as { status: string }
+      expect(json.status).toBe("accepted")
+    } finally {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v !== undefined) process.env[k] = v
+        else delete process.env[k]
+      }
+    }
+  })
+})

--- a/packages/opencode/test/server/github-webhook.test.ts
+++ b/packages/opencode/test/server/github-webhook.test.ts
@@ -6,6 +6,7 @@ import {
   formatPrivateKey,
   extractCommand,
   isAgentUser,
+  isBotComment,
   createAppJwt,
   loadConfig,
   GitHubWebhookRoutes,
@@ -149,6 +150,48 @@ describe("isAgentUser", () => {
       expect(isAgentUser("regularuser")).toBe(true) // * matches all
     } else {
       expect(isAgentUser("regularuser")).toBe(false)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isBotComment
+// ---------------------------------------------------------------------------
+
+describe("isBotComment", () => {
+  // AGENT_USERNAME is captured at module load time from GITHUB_AGENT_USERNAME.
+  // These tests validate behaviour for whatever value was captured.
+
+  test("returns true for bot usernames (ending with [bot])", () => {
+    expect(isBotComment("codexengineer[bot]")).toBe(true)
+    expect(isBotComment("some-app[bot]")).toBe(true)
+  })
+
+  test("returns false for regular human users", () => {
+    // Even when GITHUB_AGENT_USERNAME="*", isBotComment must NOT
+    // treat every user as a bot — only [bot]-suffixed logins.
+    expect(isBotComment("dzianisv")).toBe(false)
+    expect(isBotComment("regularuser")).toBe(false)
+    expect(isBotComment("admin")).toBe(false)
+  })
+
+  test("returns false for empty string", () => {
+    expect(isBotComment("")).toBe(false)
+  })
+
+  test("returns false for partial [bot] match", () => {
+    // "[bot]" must be a suffix, not a substring
+    expect(isBotComment("[bot]user")).toBe(false)
+    expect(isBotComment("user[bot")).toBe(false)
+  })
+
+  test("matches exact AGENT_USERNAME when it is not wildcard", () => {
+    // The module-level AGENT_USERNAME is read once. We can only verify
+    // the current value, but the logic is: if AGENT_USERNAME != "*",
+    // then isBotComment returns true for login === AGENT_USERNAME.
+    const agentUsername = process.env.GITHUB_AGENT_USERNAME || "opencode-agent[bot]"
+    if (agentUsername !== "*") {
+      expect(isBotComment(agentUsername)).toBe(true)
     }
   })
 })


### PR DESCRIPTION
## Summary\n- auto-build OpenCode prompt context when GitHub issue assignment/open events are received\n- add server webhook route and wiring for local issue processing\n- add tests for prompt extraction and webhook behavior\n\n## Validation\n- bun typecheck (packages/opencode)\n- bun test test/cli/github-action.test.ts test/server/github-webhook.test.ts --timeout 30000\n\nSupersedes #100.