### PR TITLE
fix(provider): keep gpt chat/codex families separate

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -877,12 +877,18 @@ export namespace Provider {
     }
   }
 
+  function normalizeFamily(model: ModelsDev.Model): string {
+    if (model.id.includes("codex")) return "gpt-codex"
+    if (model.family === "gpt-codex" && model.id.includes("-chat")) return "gpt-chat"
+    return model.family ?? ""
+  }
+
   function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model): Model {
     const m: Model = {
       id: ModelID.make(model.id),
       providerID: ProviderID.make(provider.id),
       name: model.name,
-      family: model.family,
+      family: normalizeFamily(model),
       api: {
         id: model.id,
         url: model.provider?.api ?? provider.api!,

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -71,6 +71,44 @@ test("azure/gpt-5.3-codex is backfilled when provider metadata is stale", async 
   })
 })
 
+test("models.dev family normalization keeps chat and codex tracks separate", () => {
+  const info = Provider.fromModelsDevProvider({
+    id: "azure",
+    name: "Azure",
+    env: ["AZURE_API_KEY"],
+    npm: "@ai-sdk/azure",
+    models: {
+      "gpt-5.3-chat": {
+        id: "gpt-5.3-chat",
+        name: "GPT-5.3 Chat",
+        family: "gpt-codex",
+        release_date: "2026-03-03",
+        attachment: true,
+        reasoning: true,
+        temperature: false,
+        tool_call: true,
+        options: {},
+        limit: { context: 400000, output: 128000 },
+      },
+      "gpt-5.3-codex": {
+        id: "gpt-5.3-codex",
+        name: "GPT-5.3 Codex",
+        family: "gpt-codex",
+        release_date: "2026-02-24",
+        attachment: false,
+        reasoning: true,
+        temperature: false,
+        tool_call: true,
+        options: {},
+        limit: { context: 400000, output: 128000 },
+      },
+    },
+  })
+
+  expect(info.models["gpt-5.3-chat"].family).toBe("gpt-chat")
+  expect(info.models["gpt-5.3-codex"].family).toBe("gpt-codex")
+})
+
 test("provider loaded from config with apiKey option", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
## Summary
- normalize models.dev family metadata so `*-chat` models are grouped under `gpt-chat`
- keep codex models in `gpt-codex` so `gpt-5.3-codex` remains visible in default picker filtering
- add regression coverage for chat/codex family normalization

## Validation
- bun typecheck (packages/opencode)
- bun test test/provider/provider.test.ts --timeout 30000
- runtime check: `serve` + `/provider` confirms `azure/gpt-5.3-chat` => `gpt-chat` and `azure/gpt-5.3-codex` => `gpt-codex`

Fixes model-picker visibility regression for Azure GPT-5.3 Codex.
