### PR TITLE
fix(memory): auto-truncate runtime artifacts (#115)

### DIFF
--- a/packages/opencode/src/diagnostic/memory.ts
+++ b/packages/opencode/src/diagnostic/memory.ts
@@ -302,12 +302,12 @@ export namespace Memory {
   export function start(label: string) {
     if (one.timer) return
 
-    const cfg = env()
-    if (!cfg) return
-
     void Memory.trim().catch((error) => {
       log.error("memory trim failed", { error })
     })
+
+    const cfg = env()
+    if (!cfg) return
 
     one.file =
       cfg.path || path.join(Global.Path.log, `memory-${label}-${new Date().toISOString().split(".")[0].replace(/:/g, "")}.ndjson`)

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -52,7 +52,7 @@ export namespace Log {
   export function file() {
     return logpath
   }
-  const max = 512 * 1024 * 1024
+  export const MAX = 128 * 1024 * 1024
   const step = 1024 * 1024
   const wait = 5_000
   let size = 0
@@ -113,7 +113,7 @@ export namespace Log {
     file?: string
   }) {
     const dir = input?.dir ?? Global.Path.log
-    const keep = input?.max ?? max
+    const keep = input?.max ?? MAX
     const file = input?.file ?? logpath
     const rows = (await entries(dir)).sort((a, b) => a.time - b.time)
     let total = rows.reduce((sum, row) => sum + row.size, 0)

--- a/packages/opencode/test/memory/retention.test.ts
+++ b/packages/opencode/test/memory/retention.test.ts
@@ -29,4 +29,28 @@ describe("memory retention", () => {
     expect(await fs.stat(one).catch(() => undefined)).toBeUndefined()
     expect((await fs.readdir(tmp.path)).sort()).toEqual(["three", "two"])
   })
+
+  test("defaults to keeping two snapshot directories", async () => {
+    await using tmp = await tmpdir()
+    const one = path.join(tmp.path, "one")
+    const two = path.join(tmp.path, "two")
+    const three = path.join(tmp.path, "three")
+
+    await fs.mkdir(one, { recursive: true })
+    await fs.mkdir(two, { recursive: true })
+    await fs.mkdir(three, { recursive: true })
+    await fs.writeFile(path.join(one, "meta.json"), "{}")
+    await fs.writeFile(path.join(two, "meta.json"), "{}")
+    await fs.writeFile(path.join(three, "meta.json"), "{}")
+    await fs.utimes(one, new Date("2026-03-01T00:00:00Z"), new Date("2026-03-01T00:00:00Z"))
+    await fs.utimes(two, new Date("2026-03-02T00:00:00Z"), new Date("2026-03-02T00:00:00Z"))
+    await fs.utimes(three, new Date("2026-03-03T00:00:00Z"), new Date("2026-03-03T00:00:00Z"))
+
+    await Memory.trim({
+      dir: tmp.path,
+    })
+
+    expect(await fs.stat(one).catch(() => undefined)).toBeUndefined()
+    expect((await fs.readdir(tmp.path)).sort()).toEqual(["three", "two"])
+  })
 })

--- a/packages/opencode/test/util/log.test.ts
+++ b/packages/opencode/test/util/log.test.ts
@@ -5,6 +5,10 @@ import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 
 describe("util.log", () => {
+  test("defaults log cap to 128MB", () => {
+    expect(Log.MAX).toBe(128 * 1024 * 1024)
+  })
+
   test("deletes old logs and trims the active log to stay within the cap", async () => {
     await using tmp = await tmpdir()
     const old = path.join(tmp.path, "old.log")


### PR DESCRIPTION
## Summary
- run snapshot retention trimming at `Memory.start()` before monitor env guard, so startup cleanup always runs
- reduce default log retention cap from 512MB to 128MB
- add regression tests for default snapshot keep count and log cap default

## Validation
- `bun test --cwd packages/opencode test/memory/retention.test.ts test/util/log.test.ts`
- `bun typecheck --cwd packages/opencode`

Closes #115
