### PR TITLE
feat(serve): auto-resume interrupted sessions on startup (#116)

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -9,8 +9,72 @@ import { MCP } from "../../mcp"
 import { Instance } from "../../project/instance"
 import { Log } from "../../util/log"
 import { Memory } from "../../diagnostic/memory"
+import { Session } from "../../session"
+import { SessionPrompt } from "../../session/prompt"
+import { pickResume, ResumePrompt } from "../../session/auto-resume"
+import { WorkspaceContext } from "../../control-plane/workspace-context"
+import { InstanceBootstrap } from "../../project/bootstrap"
 
 const log = Log.create({ service: "serve" })
+
+function num(name: string, fallback: number) {
+  const raw = Number(process.env[name])
+  if (!Number.isFinite(raw)) return fallback
+  return Math.max(0, Math.floor(raw))
+}
+
+async function autoresume() {
+  const scan = num("OPENCODE_SERVE_RESUME_SCAN_LIMIT", 30)
+  const max = num("OPENCODE_SERVE_RESUME_MAX", 3)
+  if (scan <= 0 || max <= 0) return
+
+  await Session.recover()
+
+  const list = [...Session.listGlobal({ limit: scan })]
+  let resumed = 0
+
+  for (const session of list) {
+    if (resumed >= max) break
+    const msgs = await Session.messages({ sessionID: session.id }).catch((error) => {
+      log.error("auto resume message load failed", { sessionID: session.id, error })
+      return
+    })
+    if (!msgs) continue
+
+    const hit = pickResume(msgs)
+    if (!hit) continue
+
+    const ok = await WorkspaceContext.provide({
+      workspaceID: session.workspaceID,
+      fn() {
+        return Instance.provide({
+          directory: session.directory,
+          init: InstanceBootstrap,
+          fn() {
+            return SessionPrompt.prompt({
+              sessionID: session.id,
+              agent: hit.user.agent,
+              model: hit.user.model,
+              variant: hit.user.variant,
+              parts: [{ type: "text", text: ResumePrompt }],
+            })
+          },
+        })
+      },
+    })
+      .then(() => true)
+      .catch((error) => {
+        log.error("auto resume failed", { sessionID: session.id, error })
+        return false
+      })
+    if (!ok) continue
+
+    resumed += 1
+    log.info("auto resumed session", { sessionID: session.id, directory: session.directory, assistantID: hit.assistant.id })
+  }
+
+  log.info("auto resume complete", { scanned: list.length, resumed, scan_limit: scan, resume_limit: max })
+}
 
 export const ServeCommand = cmd({
   command: "serve",
@@ -24,6 +88,9 @@ export const ServeCommand = cmd({
     Memory.start("serve")
     const server = Server.listen(opts)
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
+    void autoresume().catch((error) => {
+      log.error("auto resume process failed", { error })
+    })
 
     const shutdown = async (signal: string) => {
       log.warn("received signal, shutting down", { signal })

--- a/packages/opencode/src/session/auto-resume.ts
+++ b/packages/opencode/src/session/auto-resume.ts
@@ -1,0 +1,34 @@
+import { MessageV2 } from "./message-v2"
+
+export const ResumeError = "Tool execution was interrupted by server restart"
+export const ResumePrompt =
+  "Your last response was interrupted by an OpenCode server restart. Continue from the latest context without repeating completed work."
+
+export type ResumeMatch = {
+  assistant: MessageV2.Assistant
+  user: MessageV2.User
+}
+
+export function pickResume(input: MessageV2.WithParts[]) {
+  for (let i = input.length - 1; i >= 0; i--) {
+    const item = input[i]
+    if (item.info.role !== "assistant") continue
+    if (typeof item.info.time.completed !== "number") continue
+    if (
+      !item.parts.some(
+        (part) => part.type === "tool" && part.state.status === "error" && part.state.error === ResumeError,
+      )
+    )
+      continue
+    if (input.slice(i + 1).some((next) => next.info.role === "user")) continue
+
+    for (let j = i - 1; j >= 0; j--) {
+      const prev = input[j]
+      if (prev.info.role !== "user") continue
+      return {
+        assistant: item.info,
+        user: prev.info,
+      } satisfies ResumeMatch
+    }
+  }
+}

--- a/packages/opencode/test/session/auto-resume.test.ts
+++ b/packages/opencode/test/session/auto-resume.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { pickResume, ResumeError } from "../../src/session/auto-resume"
+
+const user = (input: { id: string; sessionID: string; at: number }) =>
+  ({
+    id: MessageID.make(input.id),
+    sessionID: SessionID.make(input.sessionID),
+    role: "user",
+    time: { created: input.at },
+    agent: "default",
+    model: { providerID: ProviderID.make("opencode"), modelID: ModelID.make("gpt-5-mini") },
+    mode: "build",
+  }) as unknown as MessageV2.User
+
+const assistant = (input: { id: string; sessionID: string; parentID: string; at: number }) =>
+  ({
+    id: MessageID.make(input.id),
+    sessionID: SessionID.make(input.sessionID),
+    role: "assistant",
+    time: { created: input.at - 1, completed: input.at },
+    parentID: MessageID.make(input.parentID),
+    modelID: ModelID.make("gpt-5-mini"),
+    providerID: ProviderID.make("opencode"),
+    mode: "build",
+    agent: "default",
+    path: { cwd: "/tmp", root: "/tmp" },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  }) as unknown as MessageV2.Assistant
+
+const tool = (input: { sessionID: string; messageID: string; err?: string }) =>
+  ({
+    id: PartID.make(`part-${input.messageID}`),
+    sessionID: SessionID.make(input.sessionID),
+    messageID: MessageID.make(input.messageID),
+    type: "tool",
+    callID: `call-${input.messageID}`,
+    tool: "bash",
+    state: {
+      status: "error",
+      input: {},
+      error: input.err ?? ResumeError,
+      time: { start: 1, end: 2 },
+    },
+  }) as unknown as MessageV2.ToolPart
+
+const row = (info: MessageV2.Info, parts: MessageV2.Part[] = []) => ({ info, parts }) as MessageV2.WithParts
+
+describe("session auto resume", () => {
+  test("picks interrupted assistant and previous user", () => {
+    const u1 = user({ id: "m1", sessionID: "ses_1", at: 1 })
+    const a1 = assistant({ id: "m2", sessionID: "ses_1", parentID: u1.id, at: 2 })
+    const out = pickResume([row(u1), row(a1, [tool({ sessionID: "ses_1", messageID: a1.id })])])
+
+    expect(out?.assistant.id).toBe(a1.id)
+    expect(out?.user.id).toBe(u1.id)
+  })
+
+  test("skips when user already followed interrupted assistant", () => {
+    const u1 = user({ id: "m1", sessionID: "ses_1", at: 1 })
+    const a1 = assistant({ id: "m2", sessionID: "ses_1", parentID: u1.id, at: 2 })
+    const u2 = user({ id: "m3", sessionID: "ses_1", at: 3 })
+    const out = pickResume([row(u1), row(a1, [tool({ sessionID: "ses_1", messageID: a1.id })]), row(u2)])
+    expect(out).toBeUndefined()
+  })
+
+  test("skips non-restart tool errors", () => {
+    const u1 = user({ id: "m1", sessionID: "ses_1", at: 1 })
+    const a1 = assistant({ id: "m2", sessionID: "ses_1", parentID: u1.id, at: 2 })
+    const out = pickResume([row(u1), row(a1, [tool({ sessionID: "ses_1", messageID: a1.id, err: "boom" })])])
+    expect(out).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- add serve-start auto-resume flow that scans recent global sessions and resumes interrupted ones
- detect restart-interrupted assistant turns via new `session/auto-resume` selector
- enqueue resume prompts with workspace/instance context, bounded by env-configured scan and resume limits
- add focused tests for interrupted-turn detection behavior

## Controls
- `OPENCODE_SERVE_RESUME_SCAN_LIMIT` (default `30`)
- `OPENCODE_SERVE_RESUME_MAX` (default `3`)

## Validation
- `bun test --cwd packages/opencode test/session/auto-resume.test.ts`
- `bun typecheck --cwd packages/opencode`

Closes #116
