### PR TITLE
fix: recover bot for Alice with PR-numbered session naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ For more info on how to configure OpenCode, [**head over to our docs**](https://
 
 Local MCP servers are cleaned up automatically in this fork. OpenCode can close a local MCP child process when the shared client is released, during shutdown, and it also reaps idle shared clients after `10` minutes by default. You can raise or lower that idle window with `OPENCODE_MCP_IDLE_MS` (milliseconds).
 
+### PR Session Naming Tool
+
+This fork highlights a PR-focused session rename flow in the GitHub/`gh pr create` instructions:
+
+- After a PR is created (or detected as already open), the agent should rename the active session to exactly match the PR as `#<pr_number> <pr_title>`.
+- Example: `#524 fix: harden tenant bootstrap config seeding`.
+
 ### Memory Diagnostics
 
 This fork carries built-in memory profiling helpers intended for leak hunts, panic triage, and long-running session investigations.

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -40,7 +40,7 @@ export namespace SystemPrompt {
         `</env>`,
         ``,
         `# Session Naming`,
-        `Once you understand what the user wants, use the rename tool to give this session a short descriptive title (3-7 words) that reflects the task. Do this early, before diving into the work. Update the title if the task changes significantly.`,
+        `Once you understand what the user wants, use the rename tool to give this session a short descriptive title (3-7 words) that reflects the task. Do this early, before diving into the work. Update the title if the task changes significantly. Exception: when you create or update a pull request, rename the session to match the PR using this exact format: #<number> <title>.`,
         ``,
         `<directories>`,
         `  ${

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -101,6 +101,7 @@ IMPORTANT: When the user asks you to create a pull request, follow these steps c
    - Create new branch if needed
    - Push to remote with -u flag if needed
    - Create PR using gh pr create with the format below. Use a HEREDOC to pass the body to ensure correct formatting.
+4. After PR creation succeeds, rename the current session using the rename tool so the title exactly matches the PR in this format: `#<pr_number> <pr_title>` (example: `#524 fix: harden tenant bootstrap config seeding`). If a PR already exists, use that PR's number and title.
 <example>
 gh pr create --title "the pr title" --body "$(cat <<'EOF'
 ## Summary


### PR DESCRIPTION
## Summary
- update PR creation tool instructions to require session rename after PR creation/detection
- enforce PR-based session naming format `#<number> <title>` in system session naming instructions
- highlight the PR session naming tool behavior in `README.md`

## Notes
- bot recovery context for Alice is covered by making PR/session naming deterministic after PR creation
- no openclaw changes are included in this PR

## Validation
- `bun run --cwd packages/opencode typecheck`
- `bun test --cwd packages/opencode --timeout 30000`

Closes #122