### PR TITLE
fix: instruct rename tool to use PR-numbered titles

### DIFF
--- a/packages/opencode/src/tool/rename.ts
+++ b/packages/opencode/src/tool/rename.ts
@@ -7,10 +7,14 @@ export const RenameTool = Tool.define("rename", {
     "Rename the current session to reflect what you are working on.",
     "Call this tool early in the conversation once you understand the user's task.",
     "Use a short, descriptive title (3-7 words) that summarizes the task.",
+    "When a pull request is created or updated, use the exact PR title format: '#<number> <title>'.",
     "Examples: 'Fix auth token refresh', 'Add dark mode toggle', 'Refactor database queries'",
+    "PR example: '#524 fix: harden tenant bootstrap config seeding'",
   ].join("\n"),
   parameters: z.object({
-    title: z.string().describe("Short descriptive title for the session (3-7 words)"),
+    title: z
+      .string()
+      .describe("Session title. Use 3-7 words normally; use exact '#<number> <title>' format for PR sessions."),
   }),
   async execute(params, ctx) {
     await Session.setTitle({ sessionID: ctx.sessionID, title: params.title })


### PR DESCRIPTION
## Summary
- update the rename tool description itself to require PR session titles in `#<number> <title>` format when a PR is created/updated
- add explicit PR example to rename tool guidance
- keep normal non-PR naming guidance as short 3-7 word titles

## Validation
- `bun run --cwd packages/opencode typecheck`
- `bun test --cwd packages/opencode --timeout 30000 ./test/tool/registry.test.ts ./test/tool/skill.test.ts`

Closes #124