### PR TITLE
feat: track variant-aware recent model picks

### DIFF
--- a/packages/app/src/components/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog-select-model.tsx
@@ -13,16 +13,19 @@ import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { ModelTooltip } from "./model-tooltip"
 import { useLanguage } from "@/context/language"
 
-type ModelItem = NonNullable<ReturnType<ModelState["current"]>>
-
-function itemKey(item: ModelItem) {
-  return `${item.provider.id}:${item.id}`
-}
-
 const isFree = (provider: string, cost: { input: number } | undefined) =>
   provider === "opencode" && (!cost || cost.input === 0)
 
 type ModelState = ReturnType<typeof useLocal>["model"]
+type RecentEntry = ReturnType<ModelState["recent"]>[number]
+type ModelEntry = ReturnType<ModelState["list"]>[number]
+type Item = {
+  mode: "recent" | "model"
+  group: string
+  rank: number
+  model: ModelEntry
+  variant?: RecentEntry["variant"]
+}
 
 const ModelList: Component<{
   provider?: string
@@ -33,73 +36,124 @@ const ModelList: Component<{
 }> = (props) => {
   const model = props.model ?? useLocal().model
   const language = useLanguage()
-  const recent = () => language.t("dialog.model.group.recent")
+  const recentGroup = () => language.t("dialog.model.group.recent")
+  const [store, setStore] = createStore({
+    filter: "",
+  })
 
   const models = createMemo(() =>
     model
       .list()
-      .filter((m) => model.visible({ modelID: m.id, providerID: m.provider.id }))
-      .filter((m) => (props.provider ? m.provider.id === props.provider : true)),
+      .filter((item) => model.visible({ modelID: item.id, providerID: item.provider.id }))
+      .filter((item) => (props.provider ? item.provider.id === props.provider : true)),
   )
 
   const recents = createMemo(() =>
-    new Map(
-      model.recent().flatMap((item, index) => {
-        if (!item) return []
-        return [[itemKey(item), index] as const]
-      }),
-    ),
+    model
+      .recent()
+      .filter((item) => model.visible({ modelID: item.model.id, providerID: item.model.provider.id }))
+      .filter((item) => (props.provider ? item.model.provider.id === props.provider : true)),
   )
+
+  const items = createMemo<Item[]>(() => {
+    const showSections = store.filter.trim().length === 0
+    const recent: Item[] = showSections
+      ? recents().map((item, rank): Item => ({
+          mode: "recent",
+          group: recentGroup(),
+          rank,
+          model: item.model,
+          variant: item.variant,
+        }))
+      : []
+
+    const hidden = new Set(recent.map((item) => `${item.model.provider.id}:${item.model.id}`))
+    const available: Item[] = models().flatMap((item) => {
+      if (showSections && hidden.has(`${item.provider.id}:${item.id}`)) return []
+      return [{ mode: "model", group: item.provider.name, rank: 0, model: item }]
+    })
+
+    return [...recent, ...available]
+  })
+
+  const current = createMemo(() => {
+    const item = model.current()
+    if (!item) return undefined
+
+    const variant = model.variant.current() ?? undefined
+    return (
+      items().find(
+        (entry) =>
+          entry.model.provider.id === item.provider.id &&
+          entry.model.id === item.id &&
+          (entry.mode === "model" || (entry.variant ?? undefined) === variant),
+      ) ?? items().find((entry) => entry.model.provider.id === item.provider.id && entry.model.id === item.id)
+    )
+  })
 
   return (
     <List
       class={`flex-1 min-h-0 [&_[data-slot=list-scroll]]:flex-1 [&_[data-slot=list-scroll]]:min-h-0 ${props.class ?? ""}`}
+      filter={store.filter}
+      onFilter={(value) => setStore("filter", value)}
       search={{ placeholder: language.t("dialog.model.search.placeholder"), autofocus: true, action: props.action }}
       emptyMessage={language.t("dialog.model.empty")}
-      key={itemKey}
-      items={models}
-      current={model.current()}
-      filterKeys={["provider.name", "name", "id"]}
+      key={(item) => `${item.mode}:${item.model.provider.id}:${item.model.id}:${item.variant ?? ""}`}
+      items={items()}
+      current={current()}
+      filterKeys={["model.provider.name", "model.name", "model.id", "variant"]}
       sortBy={(a, b) => {
-        const ai = recents().get(itemKey(a))
-        const bi = recents().get(itemKey(b))
-        if (ai !== undefined && bi !== undefined) return ai - bi
-        return a.name.localeCompare(b.name)
+        if (a.mode === "recent" && b.mode === "recent") return a.rank - b.rank
+        return a.model.name.localeCompare(b.model.name)
       }}
-      groupBy={(item) => (recents().has(itemKey(item)) ? recent() : item.provider.name)}
+      groupBy={(item) => item.group}
       sortGroupsBy={(a, b) => {
-        if (a.category === recent()) return -1
-        if (b.category === recent()) return 1
-        const aProvider = a.items[0].provider.id
-        const bProvider = b.items[0].provider.id
+        if (a.category === recentGroup()) return -1
+        if (b.category === recentGroup()) return 1
+
+        const aProvider = a.items[0].model.provider.id
+        const bProvider = b.items[0].model.provider.id
         if (popularProviders.includes(aProvider) && !popularProviders.includes(bProvider)) return -1
         if (!popularProviders.includes(aProvider) && popularProviders.includes(bProvider)) return 1
-        return popularProviders.indexOf(aProvider) - popularProviders.indexOf(bProvider)
+        if (popularProviders.includes(aProvider) && popularProviders.includes(bProvider)) {
+          return popularProviders.indexOf(aProvider) - popularProviders.indexOf(bProvider)
+        }
+        return a.category.localeCompare(b.category)
       }}
       itemWrapper={(item, node) => (
         <Tooltip
           class="w-full"
           placement="right-start"
           gutter={12}
-          value={<ModelTooltip model={item} latest={item.latest} free={isFree(item.provider.id, item.cost)} />}
+          value={
+            <ModelTooltip
+              model={item.model}
+              latest={item.model.latest}
+              free={isFree(item.model.provider.id, item.model.cost)}
+            />
+          }
         >
           {node}
         </Tooltip>
       )}
-      onSelect={(x) => {
-        model.set(x ? { modelID: x.id, providerID: x.provider.id } : undefined, {
-          recent: true,
-        })
+      onSelect={(item) => {
+        model.set(
+          item ? { modelID: item.model.id, providerID: item.model.provider.id } : undefined,
+          item?.mode === "recent" ? { recent: true, variant: item.variant } : { recent: true },
+        )
         props.onSelect()
       }}
     >
-      {(i) => (
+      {(item) => (
         <div class="w-full flex items-center gap-x-2 text-13-regular">
-          <span class="truncate">{i.name}</span>
-          <Show when={isFree(i.provider.id, i.cost)}>
+          <span class="truncate">{item.model.name}</span>
+          <Show when={item.mode === "recent" && item.variant}>
+            {(value) => <Tag class="capitalize">{value()}</Tag>}
+          </Show>
+          <Show when={isFree(item.model.provider.id, item.model.cost)}>
             <Tag>{language.t("model.tag.free")}</Tag>
           </Show>
-          <Show when={i.latest}>
+          <Show when={item.model.latest}>
             <Tag>{language.t("model.tag.latest")}</Tag>
           </Show>
         </div>

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -9,6 +9,7 @@ import { useProviders } from "@/hooks/use-providers"
 import { modelEnabled, modelProbe } from "@/testing/model-selection"
 import { Persist, persisted } from "@/utils/persist"
 import { cycleModelVariant, getConfiguredAgentVariant, resolveModelVariant } from "./model-variant"
+import type { RecentModel } from "./model-recent"
 import { useSDK } from "./sdk"
 import { useSync } from "./sync"
 
@@ -178,7 +179,14 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       }
     }
 
-    const fallback = createMemo<ModelKey | undefined>(() => configuredModel() ?? recentModel() ?? defaultModel())
+    const fallback = createMemo<ModelKey | undefined>(() => configuredModel() ?? recentModel() ?? preferredModel() ?? defaultModel())
+
+    const pushRecent = (item: ModelKey, variant = model.variant.current()) => {
+      models.recent.push({
+        ...item,
+        variant: variant ?? undefined,
+      })
+    }
 
     const agent = {
       list,
@@ -276,7 +284,13 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       setStore("draft", state)
     }
 
-    const recent = createMemo(() => models.recent.list().map(models.find).filter(Boolean))
+    const recent = createMemo(() =>
+      models.recent.list().flatMap((item) => {
+        const model = models.find(item)
+        if (!model) return []
+        return [{ ...item, model }] satisfies Array<RecentModel & { model: NonNullable<ReturnType<typeof models.find>> }>
+      }),
+    )
 
     const model = {
       ready: models.ready,
@@ -288,7 +302,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         const item = current()
         if (!item) return
 
-        const index = items.findIndex((entry) => entry?.provider.id === item.provider.id && entry?.id === item.id)
+        const index = items.findIndex(
+          (entry) =>
+            entry.model.provider.id === item.provider.id &&
+            entry.model.id === item.id &&
+            (entry.variant ?? undefined) === (model.variant.current() ?? undefined),
+        )
         if (index === -1) return
 
         let next = index + direction
@@ -297,9 +316,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
         const entry = items[next]
         if (!entry) return
-        model.set({ providerID: entry.provider.id, modelID: entry.id })
+        model.set(
+          { providerID: entry.model.provider.id, modelID: entry.model.id },
+          { recent: true, variant: entry.variant },
+        )
       },
-      set(item: ModelKey | undefined, options?: { recent?: boolean }) {
+      set(item: ModelKey | undefined, options?: { recent?: boolean; variant?: string }) {
         batch(() => {
           setStore("last", {
             type: "model",
@@ -307,11 +329,13 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             model: item ?? null,
             variant: selected(),
           })
-          write({ model: item })
+          if (options && "variant" in options) write({ model: item, variant: options.variant ?? null })
+          else write({ model: item })
           if (!item) return
+          if (options && "variant" in options) models.variant.set(item, options.variant)
           models.setVisibility(item, true)
           if (!options?.recent) return
-          models.recent.push(item)
+          pushRecent(item, options?.variant)
         })
       },
       visible(item: ModelKey) {
@@ -337,14 +361,16 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         },
         set(value: string | undefined) {
           batch(() => {
-            const model = current()
+            const item = current()
             setStore("last", {
               type: "variant",
               agent: agent.current()?.name,
-              model: model ? { providerID: model.provider.id, modelID: model.id } : null,
+              model: item ? { providerID: item.provider.id, modelID: item.id } : null,
               variant: value ?? null,
             })
             write({ variant: value ?? null })
+            if (!item) return
+            pushRecent({ providerID: item.provider.id, modelID: item.id }, value)
           })
         },
         cycle() {

--- a/packages/app/src/context/model-recent.test.ts
+++ b/packages/app/src/context/model-recent.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test"
+import { migrateRecent, pushRecent } from "./model-recent"
+
+describe("model recents", () => {
+  test("migrates legacy recents and keeps valid variants", () => {
+    expect(
+      migrateRecent([
+        { providerID: "azure", modelID: "gpt-5.4-pro", variant: "high" },
+        { providerID: "anthropic", modelID: "claude-opus-4-6" },
+        { providerID: "", modelID: "missing" },
+        null,
+      ]),
+    ).toEqual([
+      { providerID: "azure", modelID: "gpt-5.4-pro", variant: "high" },
+      { providerID: "anthropic", modelID: "claude-opus-4-6", variant: undefined },
+    ])
+  })
+
+  test("keeps model variants as distinct recent choices", () => {
+    const result = pushRecent(
+      [{ providerID: "azure", modelID: "gpt-5.4-pro", variant: "high" }],
+      { providerID: "azure", modelID: "gpt-5.4-pro", variant: "xhigh" },
+    )
+
+    expect(result).toEqual([
+      { providerID: "azure", modelID: "gpt-5.4-pro", variant: "xhigh" },
+      { providerID: "azure", modelID: "gpt-5.4-pro", variant: "high" },
+    ])
+  })
+
+  test("dedupes identical recent choices and caps to five", () => {
+    const result = pushRecent(
+      [
+        { providerID: "opencode", modelID: "minimax-2.5", variant: undefined },
+        { providerID: "azure", modelID: "gpt-5.4-pro", variant: "high" },
+        { providerID: "anthropic", modelID: "claude-opus-4-6", variant: undefined },
+        { providerID: "google", modelID: "gemini-2.5-pro", variant: undefined },
+        { providerID: "openai", modelID: "gpt-4.1", variant: undefined },
+      ],
+      { providerID: "azure", modelID: "gpt-5.4-pro", variant: "high" },
+    )
+
+    expect(result).toEqual([
+      { providerID: "azure", modelID: "gpt-5.4-pro", variant: "high" },
+      { providerID: "opencode", modelID: "minimax-2.5", variant: undefined },
+      { providerID: "anthropic", modelID: "claude-opus-4-6", variant: undefined },
+      { providerID: "google", modelID: "gemini-2.5-pro", variant: undefined },
+      { providerID: "openai", modelID: "gpt-4.1", variant: undefined },
+    ])
+  })
+})

--- a/packages/app/src/context/model-recent.ts
+++ b/packages/app/src/context/model-recent.ts
@@ -1,0 +1,49 @@
+export type ModelKey = {
+  providerID: string
+  modelID: string
+}
+
+export type RecentModel = ModelKey & {
+  variant?: string
+}
+
+export function recentKey(item: RecentModel) {
+  return `${item.providerID}:${item.modelID}:${item.variant ?? ""}`
+}
+
+function normalize(item: unknown) {
+  if (!item || typeof item !== "object") return
+
+  const providerID = (item as { providerID?: unknown }).providerID
+  const modelID = (item as { modelID?: unknown }).modelID
+  const variant = (item as { variant?: unknown }).variant
+  if (typeof providerID !== "string" || typeof modelID !== "string") return
+
+  const provider = providerID.trim()
+  const model = modelID.trim()
+  if (!provider || !model) return
+
+  return {
+    providerID: provider,
+    modelID: model,
+    variant: typeof variant === "string" && variant.trim() ? variant.trim() : undefined,
+  } satisfies RecentModel
+}
+
+export function migrateRecent(list: unknown) {
+  if (!Array.isArray(list)) return []
+  return list.flatMap((item) => {
+    const normalized = normalize(item)
+    return normalized ? [normalized] : []
+  })
+}
+
+export function pushRecent(list: RecentModel[], item: RecentModel, limit = 5) {
+  const seen = new Set<string>()
+  return [item, ...list].flatMap((entry) => {
+    const key = recentKey(entry)
+    if (seen.has(key)) return []
+    seen.add(key)
+    return seen.size <= limit ? [entry] : []
+  })
+}

--- a/packages/app/src/context/models.tsx
+++ b/packages/app/src/context/models.tsx
@@ -1,10 +1,11 @@
 import { createMemo } from "solid-js"
 import { createStore } from "solid-js/store"
 import { DateTime } from "luxon"
-import { filter, firstBy, flat, groupBy, mapValues, pipe, uniqueBy, values } from "remeda"
+import { filter, firstBy, flat, groupBy, mapValues, pipe, values } from "remeda"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { useProviders } from "@/hooks/use-providers"
 import { Persist, persisted } from "@/utils/persist"
+import { migrateRecent, pushRecent, type RecentModel } from "./model-recent"
 
 export type ModelKey = { providerID: string; modelID: string }
 
@@ -12,7 +13,7 @@ type Visibility = "show" | "hide"
 type User = ModelKey & { visibility: Visibility; favorite?: boolean }
 type Store = {
   user: User[]
-  recent: ModelKey[]
+  recent: RecentModel[]
   variant?: Record<string, string | undefined>
 }
 
@@ -26,9 +27,17 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
   name: "Models",
   init: () => {
     const providers = useProviders()
+    const migrate = (value: unknown) => {
+      if (!value || typeof value !== "object") return value
+      const item = value as { recent?: unknown }
+      return {
+        ...item,
+        recent: migrateRecent(item.recent),
+      }
+    }
 
     const [store, setStore, _, ready] = persisted(
-      Persist.global("model", ["model.v1"]),
+      { ...Persist.global("model", ["model.v1"]), migrate },
       createStore<Store>({
         user: [],
         recent: [],
@@ -126,10 +135,8 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       update(model, state ? "show" : "hide")
     }
 
-    const push = (model: ModelKey) => {
-      const uniq = uniqueBy([model, ...store.recent], (x) => `${x.providerID}:${x.modelID}`)
-      if (uniq.length > RECENT_LIMIT) uniq.pop()
-      setStore("recent", uniq)
+    const push = (model: RecentModel) => {
+      setStore("recent", pushRecent(store.recent, model, RECENT_LIMIT))
     }
 
     const variantKey = (model: ModelKey) => `${model.providerID}/${model.modelID}`


### PR DESCRIPTION
## Summary
- store recent model selections as distinct model-plus-variant entries and migrate older saved recents
- show a dedicated Recent section in the webapp model selector with the top 5 recent picks and restore the saved reasoning variant when selected
- cover recent-model migration and variant-aware dedupe behavior with app tests

## Validation
- bun run test
- bun run typecheck