### PR TITLE
test(instance): cover concurrent provide dedup after sweep

### DIFF
--- a/packages/opencode/test/project/instance.test.ts
+++ b/packages/opencode/test/project/instance.test.ts
@@ -60,4 +60,28 @@ describe("instance cache", () => {
     const idle = Instance.stats().entries.find((item) => item.directory === tmp.path)
     expect(idle?.refs).toBe(0)
   })
+
+  test("deduplicates concurrent create after sweep yield", async () => {
+    await using tmp = await tmpdir({ git: true })
+    let inits = 0
+
+    await Promise.all(
+      Array.from({ length: 5 }, () =>
+        Instance.provide({
+          directory: tmp.path,
+          init: async () => {
+            inits += 1
+            await Bun.sleep(5)
+          },
+          fn: async () => {
+            await Bun.sleep(1)
+            return null
+          },
+        }),
+      ),
+    )
+
+    expect(inits).toBe(1)
+    expect(Instance.stats().entries.filter((item) => item.directory === tmp.path).length).toBe(1)
+  })
 })


### PR DESCRIPTION
Add a regression test that runs five concurrent Instance.provide calls for the same directory with init hooks and asserts init executes once. This protects against the post-sweep race where each caller could create a separate instance promise for the same directory.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
