### PR TITLE
feat(app): collapsible child sessions in recent panel + /recent/session/:id routing

### DIFF
--- a/packages/app/e2e/sidebar/sidebar-recent-panel.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-recent-panel.spec.ts
@@ -136,3 +136,127 @@ test("archiving from recent sidebar removes the thread immediately", async ({ pa
     await expect(childItem).toHaveCount(0)
   })
 })
+
+test("clicking recent tile deselects the active project tile", async ({ page, withProject }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+
+  await withProject(async ({ directory, gotoSession, trackSession }) => {
+    const stamp = Date.now()
+    const title = `e2e recent highlight ${stamp}`
+    const session = await createSdk(directory).session.create({ title }).then((r) => r.data)
+    if (!session?.id) throw new Error("Session create did not return an id")
+    trackSession(session.id, directory)
+
+    await gotoSession(session.id)
+    await openSidebar(page)
+
+    const rail = page.locator('[data-component="sidebar-rail"]')
+    const recentTile = rail.getByRole("button", { name: /recent sessions/i })
+    const projectTile = rail.getByRole("button", { name: new RegExp(path.basename(directory), "i") })
+
+    // Project tile should be selected before clicking recent
+    await expect(projectTile).toHaveAttribute("class", /border-2/)
+
+    await recentTile.click()
+
+    // URL should now be canonical recent route
+    await expect(page).toHaveURL(new RegExp(`/recent/session/${session.id}`))
+
+    // Recent tile should now be selected
+    await expect(recentTile).toHaveAttribute("class", /border-2/)
+    // Project tile should no longer be highlighted with the strong border
+    await expect(projectTile).not.toHaveAttribute("class", /border-2/)
+  })
+})
+
+test("clicking recent tile with no active session navigates to /recent", async ({ page, withProject }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+
+  await withProject(async () => {
+    await page.goto("/")
+    await openSidebar(page)
+
+    const recentTile = page
+      .locator('[data-component="sidebar-rail"]')
+      .getByRole("button", { name: /recent sessions/i })
+    await recentTile.click()
+
+    await expect(page).toHaveURL("/recent")
+  })
+})
+
+test("clicking a session in recent panel keeps /recent/session/:id URL", async ({ page, withProject }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+
+  await withProject(async ({ directory, gotoSession, trackSession }) => {
+    const stamp = Date.now()
+    const first = await createSdk(directory).session.create({ title: `e2e recent url first ${stamp}` }).then((r) => r.data)
+    const second = await createSdk(directory).session.create({ title: `e2e recent url second ${stamp}` }).then((r) => r.data)
+    if (!first?.id || !second?.id) throw new Error("Session create failed")
+    trackSession(first.id, directory)
+    trackSession(second.id, directory)
+
+    await gotoSession(first.id)
+    await openSidebar(page)
+
+    const tile = page.locator('[data-component="sidebar-rail"]').getByRole("button", { name: /recent sessions/i })
+    await tile.click()
+
+    await expect(page).toHaveURL(new RegExp(`/recent/session/${first.id}`))
+
+    // Click the second session in the recent panel
+    const nav = page.locator('[data-component="sidebar-nav-desktop"]').first()
+    const secondItem = nav.locator(`[data-session-id="${second.id}"]`).first()
+    await expect(secondItem).toBeVisible()
+    await secondItem.locator("a").first().click()
+
+    await expect(page).toHaveURL(new RegExp(`/recent/session/${second.id}`))
+  })
+})
+
+test("child sessions in recent panel can be collapsed and expanded", async ({ page, withProject }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+
+  await withProject(async ({ directory, gotoSession, trackSession }) => {
+    const stamp = Date.now()
+    const rootTitle = `e2e recent collapse root ${stamp}`
+    const childTitle = `e2e recent collapse child ${stamp}`
+
+    const root = await createSdk(directory).session.create({ title: rootTitle }).then((r) => r.data)
+    if (!root?.id) throw new Error("Root session create did not return an id")
+
+    const child = await createSdk(directory).session.create({ title: childTitle, parentID: root.id }).then((r) => r.data)
+    if (!child?.id) throw new Error("Child session create did not return an id")
+
+    trackSession(root.id, directory)
+    trackSession(child.id, directory)
+
+    await gotoSession(root.id)
+    await openSidebar(page)
+
+    const tile = page.locator('[data-component="sidebar-rail"]').getByRole("button", { name: /recent sessions/i })
+    await tile.click()
+
+    const nav = page.locator('[data-component="sidebar-nav-desktop"]').first()
+    const rootItem = nav.locator(`[data-session-id="${root.id}"]`).first()
+    const childItem = nav.locator(`[data-session-id="${child.id}"]`).first()
+
+    // Children visible by default
+    await expect(childItem).toBeVisible()
+
+    // Collapse toggle button should be present on the root item
+    const toggle = rootItem.locator('[data-action="session-children-toggle"]').first()
+    await expect(toggle).toBeVisible()
+    await expect(toggle).toHaveAttribute("aria-expanded", "true")
+
+    // Click to collapse
+    await toggle.click()
+    await expect(childItem).not.toBeVisible()
+    await expect(toggle).toHaveAttribute("aria-expanded", "false")
+
+    // Click to expand again
+    await toggle.click()
+    await expect(childItem).toBeVisible()
+    await expect(toggle).toHaveAttribute("aria-expanded", "true")
+  })
+})

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -671,6 +671,8 @@ export const dict = {
   "common.delete": "Delete",
   "common.close": "Close",
   "common.edit": "Edit",
+  "common.expand": "Expand",
+  "common.collapse": "Collapse",
   "common.loadMore": "Load more",
   "common.key.esc": "ESC",
   "common.key.ctrl": "Ctrl",

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -1,36 +1,72 @@
 import { DataProvider } from "@opencode-ai/ui/context"
 import { showToast } from "@opencode-ai/ui/toast"
 import { base64Encode } from "@opencode-ai/util/encode"
-import { useLocation, useNavigate, useParams } from "@solidjs/router"
-import { createEffect, createMemo, type ParentProps, Show } from "solid-js"
+import { Navigate, useLocation, useNavigate, useParams } from "@solidjs/router"
+import { createEffect, createMemo, createResource, type ParentProps, Show } from "solid-js"
+import { useGlobalSDK } from "@/context/global-sdk"
 import { useLanguage } from "@/context/language"
 import { LocalProvider } from "@/context/local"
 import { SDKProvider } from "@/context/sdk"
 import { SyncProvider, useSync } from "@/context/sync"
 import { decode64 } from "@/utils/base64"
 
-function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
+function DirectoryDataProvider(props: ParentProps<{ directory: string; recent?: boolean }>) {
   const location = useLocation()
   const navigate = useNavigate()
   const sync = useSync()
   const slug = createMemo(() => base64Encode(props.directory))
 
   createEffect(() => {
+    if (props.recent) return
     const next = sync.data.path.directory
     if (!next || next === props.directory) return
     const path = location.pathname.slice(slug().length + 1)
     navigate(`/${base64Encode(next)}${path}${location.search}${location.hash}`, { replace: true })
   })
 
+  const nav = (id: string) => (props.recent ? `/recent/session/${id}` : `/${slug()}/session/${id}`)
+
   return (
     <DataProvider
       data={sync.data}
       directory={props.directory}
-      onNavigateToSession={(sessionID: string) => navigate(`/${slug()}/session/${sessionID}`)}
-      onSessionHref={(sessionID: string) => `/${slug()}/session/${sessionID}`}
+      onNavigateToSession={(id: string) => navigate(nav(id))}
+      onSessionHref={(id: string) => nav(id)}
     >
       <LocalProvider>{props.children}</LocalProvider>
     </DataProvider>
+  )
+}
+
+function RecentSessionLayout(props: ParentProps<{ id: string }>) {
+  const globalSDK = useGlobalSDK()
+  const navigate = useNavigate()
+
+  const [directory] = createResource(
+    () => props.id,
+    (id) =>
+      globalSDK.client.session
+        .get({ sessionID: id })
+        .then((x) => x.data?.directory ?? "")
+        .catch(() => ""),
+  )
+
+  createEffect(() => {
+    if (directory.state === "ready" && !directory()) navigate("/recent", { replace: true })
+  })
+
+  return (
+    <Show when={directory()} keyed>
+      {(dir) => (
+        <SDKProvider directory={() => dir}>
+          <SyncProvider>
+            <DirectoryDataProvider directory={dir} recent>
+              {props.children}
+            </DirectoryDataProvider>
+          </SyncProvider>
+        </SDKProvider>
+      )}
+    </Show>
   )
 }
 
@@ -40,12 +76,16 @@ export default function Layout(props: ParentProps) {
   const navigate = useNavigate()
   let invalid = ""
 
+  const isRecent = createMemo(() => params.dir === "recent")
+
   const resolved = createMemo(() => {
+    if (isRecent()) return ""
     if (!params.dir) return ""
     return decode64(params.dir) ?? ""
   })
 
   createEffect(() => {
+    if (isRecent()) return
     const dir = params.dir
     if (!dir) return
     if (resolved()) {
@@ -63,14 +103,23 @@ export default function Layout(props: ParentProps) {
   })
 
   return (
-    <Show when={resolved()} keyed>
-      {(resolved) => (
-        <SDKProvider directory={() => resolved}>
-          <SyncProvider>
-            <DirectoryDataProvider directory={resolved}>{props.children}</DirectoryDataProvider>
-          </SyncProvider>
-        </SDKProvider>
-      )}
+    <Show
+      when={isRecent()}
+      fallback={
+        <Show when={resolved()} keyed>
+          {(dir) => (
+            <SDKProvider directory={() => dir}>
+              <SyncProvider>
+                <DirectoryDataProvider directory={dir}>{props.children}</DirectoryDataProvider>
+              </SyncProvider>
+            </SDKProvider>
+          )}
+        </Show>
+      }
+    >
+      <Show when={params.id} fallback={<Navigate href="/recent" />}>
+        {(id) => <RecentSessionLayout id={id()}>{props.children}</RecentSessionLayout>}
+      </Show>
     </Show>
   )
 }

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -159,7 +159,11 @@ export default function Layout(props: ParentProps) {
     sizing: false,
     peek: undefined as string | undefined,
     peeked: false,
-    recent: false,
+    recent: params.dir === "recent",
+  })
+
+  createEffect(() => {
+    setState("recent", params.dir === "recent")
   })
 
   const editor = createInlineEditorController()
@@ -1036,7 +1040,7 @@ export default function Layout(props: ParentProps) {
       if (nextSession) {
         navigate(`/${params.dir}/session/${nextSession.id}`)
       } else {
-        navigate(`/${params.dir}/session`)
+        navigate(params.dir === "recent" ? "/recent" : `/${params.dir}/session`)
       }
     }
     return true
@@ -2042,6 +2046,7 @@ export default function Layout(props: ParentProps) {
   const projectSidebarCtx: ProjectSidebarContext = {
     currentDir,
     currentProject,
+    recentMode: () => state.recent,
     sidebarOpened: () => layout.sidebar.opened(),
     sidebarHovering,
     hoverProject: () => state.hoverProject,
@@ -2394,6 +2399,7 @@ export default function Layout(props: ParentProps) {
     clearHoverProjectSoon,
     prefetchSession,
     archiveSession,
+    collapsible: true,
   }
 
   const projects = () => layout.projects.list()
@@ -2423,7 +2429,7 @@ export default function Layout(props: ParentProps) {
         <RecentTile
           selected={() => state.recent}
           onClick={() => {
-            setState("recent", true)
+            navigate(params.id ? `/recent/session/${params.id}` : "/recent")
             layout.sidebar.open()
           }}
         />

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -9,7 +9,7 @@ import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { getFilename } from "@opencode-ai/util/path"
 import { A, useNavigate, useParams } from "@solidjs/router"
-import { type Accessor, createMemo, For, type JSX, Match, onCleanup, Show, Switch } from "solid-js"
+import { type Accessor, createMemo, createSignal, For, type JSX, Match, onCleanup, Show, Switch } from "solid-js"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { getAvatarColors, type LocalProject, useLayout } from "@/context/layout"
@@ -77,6 +77,7 @@ export type SessionItemProps = {
   mobile?: boolean
   dense?: boolean
   popover?: boolean
+  collapsible?: boolean
   children: ReadonlyMap<string, string[]>
   depth?: number
   sidebarExpanded: Accessor<boolean>
@@ -334,6 +335,10 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       .filter((s): s is Session => s !== undefined && !s.time?.archived),
   )
 
+  const [collapsed, setCollapsed] = createSignal(false)
+  const hasChildren = createMemo(() => childSessions().length > 0)
+  const showToggle = createMemo(() => props.collapsible && hasChildren())
+
   return (
     <>
       <div
@@ -342,6 +347,23 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
                hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[[data-expanded]]:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active"
         style={{ "padding-left": pad() }}
       >
+        <Show when={showToggle()}>
+          <button
+            type="button"
+            aria-label={collapsed() ? language.t("common.expand") : language.t("common.collapse")}
+            aria-expanded={!collapsed()}
+            data-action="session-children-toggle"
+            class="absolute left-1 top-0 bottom-0 flex items-center justify-center w-5 z-10 text-icon-weak hover:text-icon-base focus:outline-none"
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              setCollapsed((c) => !c)
+            }}
+          >
+            <Icon name={collapsed() ? "chevron-right" : "chevron-down"} size="small" />
+          </button>
+        </Show>
+
         <Show
           when={hoverEnabled()}
           fallback={
@@ -401,31 +423,34 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
           </Tooltip>
         </div>
       </div>
-      <For each={childSessions()}>
-        {(child) => (
-          <SessionItem
-            session={child}
-            list={props.list}
-            navList={props.navList}
-            lookup={props.lookup}
-            prefixes={props.prefixes}
-            slug={props.slug}
-            mobile={props.mobile}
-            dense={props.dense}
-            popover={props.popover}
-            children={props.children}
-            depth={depth() + 1}
-            sidebarExpanded={props.sidebarExpanded}
-            sidebarHovering={props.sidebarHovering}
-            nav={props.nav}
-            hoverSession={props.hoverSession}
-            setHoverSession={props.setHoverSession}
-            clearHoverProjectSoon={props.clearHoverProjectSoon}
-            prefetchSession={props.prefetchSession}
-            archiveSession={props.archiveSession}
-          />
-        )}
-      </For>
+      <Show when={!collapsed()}>
+        <For each={childSessions()}>
+          {(child) => (
+            <SessionItem
+              session={child}
+              list={props.list}
+              navList={props.navList}
+              lookup={props.lookup}
+              prefixes={props.prefixes}
+              slug={props.slug}
+              mobile={props.mobile}
+              dense={props.dense}
+              popover={props.popover}
+              collapsible={props.collapsible}
+              children={props.children}
+              depth={depth() + 1}
+              sidebarExpanded={props.sidebarExpanded}
+              sidebarHovering={props.sidebarHovering}
+              nav={props.nav}
+              hoverSession={props.hoverSession}
+              setHoverSession={props.setHoverSession}
+              clearHoverProjectSoon={props.clearHoverProjectSoon}
+              prefetchSession={props.prefetchSession}
+              archiveSession={props.archiveSession}
+            />
+          )}
+        </For>
+      </Show>
     </>
   )
 }

--- a/packages/app/src/pages/layout/sidebar-project.tsx
+++ b/packages/app/src/pages/layout/sidebar-project.tsx
@@ -16,6 +16,7 @@ import { childMapByParent, displayName, sortedRootSessions } from "./helpers"
 export type ProjectSidebarContext = {
   currentDir: Accessor<string>
   currentProject: Accessor<LocalProject | undefined>
+  recentMode: Accessor<boolean>
   sidebarOpened: Accessor<boolean>
   sidebarHovering: Accessor<boolean>
   hoverProject: Accessor<string | undefined>
@@ -285,7 +286,9 @@ export const SortableProject = (props: {
   const globalSync = useGlobalSync()
   const language = useLanguage()
   const sortable = createSortable(props.project.worktree)
-  const selected = createMemo(() => props.ctx.currentProject()?.worktree === props.project.worktree)
+  const selected = createMemo(
+    () => !props.ctx.recentMode() && props.ctx.currentProject()?.worktree === props.project.worktree,
+  )
   const workspaces = createMemo(() => props.ctx.workspaceIds(props.project).slice(0, 2))
   const workspaceEnabled = createMemo(() => props.ctx.workspacesEnabled(props.project))
   const dirs = createMemo(() => props.ctx.workspaceIds(props.project))

--- a/packages/app/src/pages/layout/sidebar-recent.tsx
+++ b/packages/app/src/pages/layout/sidebar-recent.tsx
@@ -1,6 +1,5 @@
 import { createEffect, createMemo, For, on, Show, type Accessor, type JSX } from "solid-js"
 import { createStore } from "solid-js/store"
-import { base64Encode } from "@opencode-ai/util/encode"
 import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
@@ -108,7 +107,7 @@ export const RecentSidebarPanel = (props: {
     timer = setTimeout(() => setStore("search", val), 300)
   }
 
-  const slug = (session: GlobalSession) => base64Encode(session.directory)
+  const slug = (_session: GlobalSession) => "recent"
   const archiveSession = async (session: Session) => {
     const ok = await props.sessionProps.archiveSession(session)
     if (!ok) return false

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -554,7 +554,7 @@ export function MessageTimeline(props: {
       navigate(`/${params.dir}/session/${nextSessionID}`)
       return
     }
-    navigate(`/${params.dir}/session`)
+    navigate(params.dir === "recent" ? "/recent" : `/${params.dir}/session`)
   }
 
   const archiveSession = async (sessionID: string) => {

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -247,7 +247,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
         title: language.t("command.session.new"),
         keybind: "mod+shift+s",
         slash: "new",
-        onSelect: () => navigate(`/${params.dir}/session`),
+        onSelect: () => navigate(params.dir === "recent" ? "/recent" : `/${params.dir}/session`),
       }),
       fileCommand({
         id: "file.open",


### PR DESCRIPTION
## Summary

Implements collapsible child/subagent sessions in the Recent Sessions sidebar panel and fixes the dual-highlight bug.

### Changes

**1. Fix dual-highlight bug** — project rail tile no longer highlighted when in recent mode (`recentMode` added to `ProjectSidebarContext`)

**2. Collapsible child/subagent sessions** — chevron toggle with `data-action="session-children-toggle"` + `aria-expanded`; `common.expand`/`common.collapse` i18n keys added

**3. Canonical `/recent/session/:id` URL routing** — `params.dir === "recent"` sentinel in existing route; `directory-layout.tsx` resolves real directory via `globalSDK.client.session.get()`; all recent panel links emit `/recent/session/:id`; safe fallback to `/recent` when no next session

### Testing
- 4 new e2e tests in `sidebar-recent-panel.spec.ts`
- Build passes ✅