### PR TITLE
fix: prevent phantom project reopen on /recent refresh

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -127,10 +127,10 @@ export default function Layout(props: ParentProps) {
   const command = useCommand()
   const theme = useTheme()
   const language = useLanguage()
-  const initialDirectory = decode64(params.dir)
+  const initialDirectory = params.dir === "recent" ? undefined : decode64(params.dir)
   const route = createMemo(() => {
     const slug = params.dir
-    if (!slug) return { slug, dir: "" }
+    if (!slug || slug === "recent") return { slug, dir: "" }
     const dir = decode64(slug)
     if (!dir) return { slug, dir: "" }
     return {

--- a/packages/app/src/utils/base64.test.ts
+++ b/packages/app/src/utils/base64.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { decode64 } from "./base64"
+
+describe("decode64", () => {
+  test("decodes a valid base64-encoded path", () => {
+    // base64Encode("/home/user") from @opencode-ai/util/encode
+    const encoded = "L2hvbWUvdXNlcg"
+    expect(decode64(encoded)).toBe("/home/user")
+  })
+
+  test("returns undefined for undefined input", () => {
+    expect(decode64(undefined)).toBeUndefined()
+  })
+
+  test("returns undefined for non-base64 route names like 'recent'", () => {
+    // "recent" is valid base64 alphabet but decodes to invalid UTF-8 bytes
+    // [0xAD, 0xE7, 0x9E, 0x9B] — this MUST NOT produce a garbage truthy string
+    expect(decode64("recent")).toBeUndefined()
+  })
+
+  test("returns undefined for completely invalid base64", () => {
+    expect(decode64("!!!not-base64!!!")).toBeUndefined()
+  })
+
+  test("decodes url-safe base64 with dashes and underscores", () => {
+    // A path with characters that produce + and / in standard base64
+    const path = "/tmp/a+b/c=d"
+    // Manually: base64Encode produces url-safe variant
+    const encoded = "L3RtcC9hK2IvYz1k"
+    expect(decode64(encoded)).toBe(path)
+  })
+})

--- a/packages/util/src/encode.ts
+++ b/packages/util/src/encode.ts
@@ -7,7 +7,7 @@ export function base64Encode(value: string) {
 export function base64Decode(value: string) {
   const binary = atob(value.replace(/-/g, "+").replace(/_/g, "/"))
   const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0))
-  return new TextDecoder().decode(bytes)
+  return new TextDecoder("utf-8", { fatal: true }).decode(bytes)
 }
 
 export async function hash(content: string, algorithm = "SHA-256"): Promise<string> {


### PR DESCRIPTION
## What changed
- reject invalid UTF-8 in base64 decoding by using `TextDecoder('utf-8', { fatal: true })`
- guard `params.dir === 'recent'` in layout route resolution
- add regression test: `decode64('recent')` returns `undefined`

## Why
`base64Decode('recent')` previously produced a truthy garbage string, which caused phantom workspace reopen persistence on refresh.

Fixes #162