### PR TITLE
fix: restore Vcs.diff, Vcs.defaultBranch, Vcs.Mode stripped by rebase reconciliation

### DIFF
--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -4,13 +4,72 @@ import { BusEvent } from "@/bus/bus-event"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRunPromise } from "@/effect/run-service"
 import { FileWatcher } from "@/file/watcher"
+import { Git } from "@/git"
+import { Snapshot } from "@/snapshot"
 import { Log } from "@/util/log"
 import { git } from "@/util/git"
+import path from "path"
 import { Instance } from "./instance"
 import z from "zod"
 
 export namespace Vcs {
   const log = Log.create({ service: "vcs" })
+  const count = (text: string) => {
+    if (!text) return 0
+    if (!text.endsWith("\n")) return text.split("\n").length
+    return text.slice(0, -1).split("\n").length
+  }
+
+  const work = async (cwd: string, file: string) => {
+    const full = path.join(cwd, file)
+    const next = Bun.file(full)
+    if (!(await next.exists())) return ""
+    const text = await next.text().catch(() => "")
+    if (text.includes("\u0000")) return ""
+    return text
+  }
+
+  const nums = (list: Git.Stat[]) => {
+    return new Map(list.map((item) => [item.file, item] as const))
+  }
+
+  const merge = (...list: Git.Item[][]) => {
+    const out = new Map<string, Git.Item>()
+    list.flat().forEach((item) => {
+      if (out.has(item.file)) return
+      out.set(item.file, item)
+    })
+    return [...out.values()]
+  }
+
+  const CONCURRENCY = 8
+
+  const files = async (cwd: string, ref: string | undefined, list: Git.Item[], map: Map<string, Git.Stat>, root: string) => {
+    const results: Snapshot.FileDiff[] = []
+    for (let i = 0; i < list.length; i += CONCURRENCY) {
+      const batch = list.slice(i, i + CONCURRENCY)
+      const chunk = await Promise.all(
+        batch.map(async (item) => {
+          const before = item.status === "added" || !ref ? "" : await Git.show(cwd, ref, item.file, root)
+          const after = item.status === "deleted" ? "" : await work(cwd, item.file)
+          const stat = map.get(item.file)
+          return {
+            file: item.file,
+            before,
+            after,
+            additions: stat?.additions ?? (item.status === "added" ? count(after) : 0),
+            deletions: stat?.deletions ?? (item.status === "deleted" ? count(before) : 0),
+            status: item.status,
+          } satisfies Snapshot.FileDiff
+        }),
+      )
+      results.push(...chunk)
+    }
+    return results.toSorted((a, b) => a.file.localeCompare(b.file))
+  }
+
+  export const Mode = z.enum(["git", "branch"])
+  export type Mode = z.infer<typeof Mode>
 
   export const Event = {
     BranchUpdated: BusEvent.define(
@@ -108,5 +167,41 @@ export namespace Vcs {
 
   export function branch() {
     return runPromise((svc) => svc.branch())
+  }
+
+  export async function defaultBranch() {
+    if (Instance.project.vcs !== "git") return undefined
+    return Git.defaultBranch(Instance.directory).then((b) => b?.name)
+  }
+
+  export async function diff(mode: Mode): Promise<Snapshot.FileDiff[]> {
+    if (Instance.project.vcs !== "git") return []
+    const cwd = Instance.directory
+    if (mode === "git") {
+      const has = await Git.hasHead(cwd)
+      const list = await Git.status(cwd)
+      if (!has) return files(cwd, undefined, list, new Map(), "")
+      const [stats, root] = await Promise.all([Git.stats(cwd, "HEAD"), Git.prefix(cwd)])
+      return files(cwd, "HEAD", list, nums(stats), root)
+    }
+
+    const base = await Git.defaultBranch(cwd)
+    if (!base) return []
+    const head = await Git.branch(cwd)
+    if (head && head === base.name) return []
+    const ref = await Git.mergeBase(cwd, base.ref)
+    if (!ref) return []
+
+    const [list, stats, seen, root] = await Promise.all([Git.diff(cwd, ref), Git.stats(cwd, ref), Git.status(cwd), Git.prefix(cwd)])
+    return files(
+      cwd,
+      ref,
+      merge(
+        list,
+        seen.filter((item) => item.code === "??"),
+      ),
+      nums(stats),
+      root,
+    )
   }
 }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -41,6 +41,7 @@ import { websocket } from "hono/bun"
 import { HTTPException } from "hono/http-exception"
 import { errors } from "./error"
 import { Filesystem } from "@/util/filesystem"
+import { Snapshot } from "@/snapshot"
 import { QuestionRoutes } from "./routes/question"
 import { PermissionRoutes } from "./routes/permission"
 import { GlobalRoutes } from "./routes/global"
@@ -355,10 +356,38 @@ export namespace Server {
           },
         }),
         async (c) => {
-          const branch = await Vcs.branch()
+          const [branch, default_branch] = await Promise.all([Vcs.branch(), Vcs.defaultBranch()])
           return c.json({
             branch,
+            default_branch,
           })
+        },
+      )
+      .get(
+        "/vcs/diff",
+        describeRoute({
+          summary: "Get VCS diff",
+          description: "Retrieve the current git diff for the working tree or against the default branch.",
+          operationId: "vcs.diff",
+          responses: {
+            200: {
+              description: "VCS diff",
+              content: {
+                "application/json": {
+                  schema: resolver(Snapshot.FileDiff.array()),
+                },
+              },
+            },
+          },
+        }),
+        validator(
+          "query",
+          z.object({
+            mode: Vcs.Mode,
+          }),
+        ),
+        async (c) => {
+          return c.json(await Vcs.diff(c.req.valid("query").mode))
         },
       )
       .get(

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -179,6 +179,7 @@ import type {
   TuiSelectSessionResponses,
   TuiShowToastResponses,
   TuiSubmitPromptResponses,
+  VcsDiffResponses,
   VcsGetResponses,
   WorktreeCreateErrors,
   WorktreeCreateInput,
@@ -3892,6 +3893,38 @@ export class Vcs extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<VcsGetResponses, unknown, ThrowOnError>({
       url: "/vcs",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get VCS diff
+   *
+   * Retrieve the current git diff for the working tree or against the default branch.
+   */
+  public diff<ThrowOnError extends boolean = false>(
+    parameters: {
+      directory?: string
+      workspace?: string
+      mode: "git" | "branch"
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "mode" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<VcsDiffResponses, unknown, ThrowOnError>({
+      url: "/vcs/diff",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1121,6 +1121,14 @@ export type Config = {
    * Additional instruction files or patterns to include
    */
   instructions?: Array<string>
+  scheduler?: {
+    enabled?: boolean
+    heartbeat?: {
+      enabled?: boolean
+      interval?: string
+    }
+    maxConcurrent?: number
+  }
   layout?: LayoutConfig
   permission?: PermissionConfig
   /**
@@ -1207,10 +1215,6 @@ export type Config = {
      * Timeout in milliseconds for model context protocol (MCP) requests
      */
     mcp_timeout?: number
-    /**
-     * Timeout in milliseconds between stream chunks from LLM. If no data is received within this period, the request will be retried. Default is 60000 (60 seconds). Set to 0 to disable.
-     */
-    stream_idle_timeout?: number
   }
 }
 
@@ -5094,6 +5098,26 @@ export type VcsGetResponses = {
 }
 
 export type VcsGetResponse = VcsGetResponses[keyof VcsGetResponses]
+
+export type VcsDiffData = {
+  body?: never
+  path?: never
+  query: {
+    directory?: string
+    workspace?: string
+    mode: "git" | "branch"
+  }
+  url: "/vcs/diff"
+}
+
+export type VcsDiffResponses = {
+  /**
+   * VCS diff
+   */
+  200: Array<FileDiff>
+}
+
+export type VcsDiffResponse = VcsDiffResponses[keyof VcsDiffResponses]
 
 export type CommandListData = {
   body?: never


### PR DESCRIPTION
## Problem

The session page fails to load with:
```
TypeError: l.client.vcs.diff is not a function
```

## Root cause

Commit `850a1823d` (fix(rebase): reconcile upstream replay regressions) accidentally stripped `Vcs.Mode`, `Vcs.defaultBranch()`, and `Vcs.diff()` from `packages/opencode/src/project/vcs.ts`, while `instance.ts` still references them.

Additionally, `server.ts` was missing the `/vcs/diff` route needed for OpenAPI spec generation, so the SDK never produced the `Vcs.diff()` client method.

## Changes

- **vcs.ts**: Restore `Vcs.Mode` (zod enum), `Vcs.defaultBranch()` with VCS guard, and `Vcs.diff(mode)` with concurrency-limited (8) file reading
- **server.ts**: Add `/vcs/diff` route + `default_branch` to `/vcs` response (mirrors `instance.ts`)
- **SDK**: Regenerated — `Vcs.diff()` method now exists in the v2 SDK

## Verification

- bun typecheck — zero vcs/instance/server errors (fixes 3 session.tsx errors on dev)
- bun run build (app) — succeeds
- bun run install:local — succeeds with smoke test
- SDK has public diff() on Vcs class

Fixes #179