### PR TITLE
fix: improve auto-review controls

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1919,6 +1919,40 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                         </TooltipKeybind>
                       </div>
                     </Show>
+                    <div
+                      data-component="prompt-auto-review-control"
+                      style={providersShouldFadeIn() ? { animation: "fade-in 0.3s" } : undefined}
+                    >
+                      <Button
+                        data-action="prompt-auto-review"
+                        type="button"
+                        variant="ghost"
+                        size="normal"
+                        class="h-7 px-2 gap-1 text-13-regular text-text-base"
+                        classList={{
+                          "bg-surface-raised-base-active": settings.models.autoReview(),
+                        }}
+                        style={control()}
+                        onClick={() => {
+                          settings.models.setAutoReview(!settings.models.autoReview())
+                          restoreFocus()
+                        }}
+                        aria-pressed={settings.models.autoReview()}
+                      >
+                        <Icon
+                          name="checklist"
+                          size="small"
+                          classList={{
+                            "text-icon-success-base": settings.models.autoReview(),
+                            "text-icon-base": !settings.models.autoReview(),
+                          }}
+                        />
+                        <span>Review</span>
+                        <Show when={!settings.models.autoReview()}>
+                          <span class="text-11-regular text-text-weak">off</span>
+                        </Show>
+                      </Button>
+                    </div>
                   </Show>
                 </Show>
               </div>

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1665,7 +1665,7 @@ export default function Page() {
     const agent = input.assistant.agent ?? local.agent.current()?.name
     if (!review || !agent) return
 
-    const previous = `${input.assistant.providerID}/${input.assistant.modelID}`
+    const previous = `${input.worker.providerID}/${input.worker.modelID}`
     const text = input.phase === "supervisor" ? reviewPrompt(previous) : reviewPromptFor(previous, input.phase)
 
     setFollowup("items", sessionID, (items) => [

--- a/packages/app/src/pages/session/auto-review.test.ts
+++ b/packages/app/src/pages/session/auto-review.test.ts
@@ -22,15 +22,18 @@ describe("reviewPrompt", () => {
 
   test("supports cross-review prompt kind", () => {
     const text = reviewPromptFor("openai/gpt-5", "cross-review")
-    expect(text).toContain("Codex, run cross-review")
+    expect(text).toContain("Run cross-review")
   })
 })
 
 describe("reviewPrompt parsing", () => {
-  test("matches prompt kind by prefix", () => {
+  test("matches prompt kind by new and old prefixes", () => {
     expect(reviewPromptCheck(reviewPrompt("openai/gpt-5"))).toBe(true)
     expect(reviewPromptKind(reviewPrompt("openai/gpt-5"))).toBe("supervisor")
     expect(reviewPromptKind(reviewPromptFor("openai/gpt-5", "cross-review"))).toBe("cross-review")
+    expect(reviewPromptKind("Run auto-review for openai/gpt-5 work.")).toBe("supervisor")
+    expect(reviewPromptKind("Codex, run supervisor review for openai/gpt-5 work.")).toBe("supervisor")
+    expect(reviewPromptKind("Codex, run cross-review for openai/gpt-5 work.")).toBe("cross-review")
     expect(reviewPromptKind("Codex, run auto-review for openai/gpt-5 work.")).toBe("supervisor")
     expect(reviewPromptCheck("hello")).toBe(false)
     expect(reviewPromptKind("hello")).toBeUndefined()

--- a/packages/app/src/pages/session/auto-review.ts
+++ b/packages/app/src/pages/session/auto-review.ts
@@ -28,10 +28,10 @@ type PickOutput = {
 export type ReviewKind = "supervisor" | "cross-review"
 
 const heads: Record<ReviewKind, string> = {
-  supervisor: "Codex, run supervisor review",
-  "cross-review": "Codex, run cross-review",
+  supervisor: "Run supervisor review",
+  "cross-review": "Run cross-review",
 }
-const legacy = "Codex, run auto-review"
+const legacy = "Run auto-review"
 const done = "Task completed."
 
 const key = (item: Key) => `${item.providerID}/${item.modelID}`
@@ -81,6 +81,9 @@ export const reviewPromptKind = (text: string): ReviewKind | undefined => {
   if (line.startsWith(heads.supervisor.toLowerCase())) return "supervisor"
   if (line.startsWith(heads["cross-review"].toLowerCase())) return "cross-review"
   if (line.startsWith(legacy.toLowerCase())) return "supervisor"
+  if (line.startsWith("codex, run supervisor review")) return "supervisor"
+  if (line.startsWith("codex, run cross-review")) return "cross-review"
+  if (line.startsWith("codex, run auto-review")) return "supervisor"
 }
 
 export const reviewPromptCheck = (text: string) => !!reviewPromptKind(text)


### PR DESCRIPTION
## Summary
- add a Review toggle pill to the prompt toolbar next to model/variant controls
- remove Codex branding from auto-review prompts while keeping backward-compatible prompt parsing
- keep auto-review prompts tied to the original worker model to prevent confusing cascaded re-review prompts

## Testing
- `cd packages/opencode && bun typecheck`
- `cd packages/app && bun test auto-review`
- `cd packages/app && bun typecheck`

Closes #200