### PR TITLE
fix(config): avoid plugin version pin on preview builds

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/config/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui.ts
@@ -217,7 +217,10 @@ export const layer = Layer.effect(
             add: [
               {
                 name: "@opencode-ai/plugin",
-                version: InstallationLocal ? undefined : InstallationVersion,
+                version:
+                  InstallationLocal || InstallationVersion.startsWith("0.0.0--")
+                    ? undefined
+                    : InstallationVersion,
               },
             ],
           })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -647,7 +647,10 @@ export const layer = Layer.effect(
               add: [
                 {
                   name: "@opencode-ai/plugin",
-                  version: InstallationLocal ? undefined : InstallationVersion,
+                  version:
+                    InstallationLocal || InstallationVersion.startsWith("0.0.0--")
+                      ? undefined
+                      : InstallationVersion,
                 },
               ],
             })


### PR DESCRIPTION
## Summary
- avoid pinning `@opencode-ai/plugin` to preview-only versions like `0.0.0--...`
- install plugin dependency as unpinned (`latest`) for local/preview builds in both server config loader and TUI config loader
- keep version pinning for published channels

## Why
Preview binaries can reference plugin package versions that are not published, causing dependency install failures and immediate session aborts when `.opencode/tool/*.ts` imports `@opencode-ai/plugin`.

Closes #215