### PR TITLE
fix(tool): orDie session tool execute to satisfy Tool.Def's never-error channel

### DIFF
--- a/packages/opencode/src/tool/session.ts
+++ b/packages/opencode/src/tool/session.ts
@@ -51,7 +51,7 @@ export const SessionTool = Tool.define<typeof Parameters, Metadata, Session.Serv
             output: `Session renamed to: "${params.title}"`,
             metadata: {},
           }
-        }),
+        }).pipe(Effect.orDie),
     } satisfies Tool.DefWithoutID<typeof Parameters, Metadata>
   }),
 )


### PR DESCRIPTION
### Issue for this PR

Closes #218

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

\`Tool.Def.execute\` requires \`Effect<ExecuteResult<M>, never, never>\`, but the body of \`src/tool/session.ts\` uses \`session.get(...)\` which returns \`Effect<Info, NotFound>\`. The \`NotFound\` escapes through \`execute\`, breaks the type signature, and makes \`bun typecheck\` fail on \`dev\` (and any branch pushed against it via the husky pre-push hook).

Fix: pipe the inner \`Effect.gen\` through \`Effect.orDie\`. This converts the \`NotFound\` error into a defect so the execute signature lines up with the rest of the tool registry. This is exactly the pattern every other tool in \`src/tool/\` already uses — glob.ts, read.ts, edit.ts, codesearch.ts, autopilot.ts, question.ts, lsp.ts, skill.ts, truncate.ts.

Behavior: unchanged for the success paths. On the previously-untyped failure path (session id does not exist), the tool now dies cleanly instead of returning a value with a hidden error channel — same outcome the type system already assumed.

### How did you verify your code works?

- \`cd packages/opencode && bun run typecheck\` → previously errored on lines 18 and 30 of \`src/tool/session.ts\`; now clean.
- \`git push\` on a branch without \`--no-verify\` → pre-push hook now passes.

### Screenshots / recordings

N/A — type-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR