### PR TITLE
fix(session): add periodic status reconciler to clear stale busy sessions

### DIFF
--- a/packages/opencode/src/cli/cmd/serve-reconciler.ts
+++ b/packages/opencode/src/cli/cmd/serve-reconciler.ts
@@ -1,0 +1,47 @@
+import { Cause, Duration, Effect, Schedule } from "effect"
+import { WorkspaceRef } from "@/effect/instance-ref"
+import { InstanceStore } from "@/project/instance-store"
+import { SessionRunState } from "@/session/run-state"
+import * as Session from "@/session/session"
+
+function num(key: string, fallback: number) {
+  const raw = Number(process.env[key])
+  if (!Number.isFinite(raw)) return fallback
+  return Math.max(0, Math.floor(raw))
+}
+
+const reconcileOnce = Effect.fn("Cli.serve.reconcileOnce")(function* () {
+  const scan = num("OPENCODE_SERVE_RECONCILE_SCAN_LIMIT", 100)
+  if (scan <= 0) return
+
+  const rows = yield* Effect.sync(() => [...Session.listGlobal({ limit: scan })])
+  const store = yield* InstanceStore.Service
+  const seen = new Set<string>()
+
+  for (const item of rows) {
+    if (seen.has(item.directory)) continue
+    seen.add(item.directory)
+
+    yield* store
+      .provide(
+        { directory: item.directory },
+        Effect.gen(function* () {
+          const runState = yield* SessionRunState.Service
+          yield* runState.reconcile()
+        }),
+      )
+      .pipe(
+        Effect.provideService(WorkspaceRef, item.workspaceID),
+        Effect.catchCause((cause) => {
+          const error = Cause.squash(cause)
+          return Effect.logWarning("status reconcile failed", { directory: item.directory, error })
+        }),
+      )
+  }
+})
+
+export const reconciler = Effect.fn("Cli.serve.reconciler")(function* () {
+  const intervalSeconds = num("OPENCODE_SERVE_RECONCILE_INTERVAL_S", 30)
+  if (intervalSeconds <= 0) return
+  yield* reconcileOnce().pipe(Effect.repeat(Schedule.spaced(Duration.seconds(intervalSeconds))), Effect.ignore)
+})

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -4,6 +4,7 @@ import { effectCmd } from "../effect-cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { autoresume } from "./serve-autoresume"
+import { reconciler } from "./serve-reconciler"
 import { Scheduler } from "@/scheduler"
 
 export const ServeCommand = effectCmd({
@@ -33,6 +34,11 @@ export const ServeCommand = effectCmd({
         )
         yield* autoresume().pipe(
           Effect.catchCause((cause) => Effect.logWarning("auto resume process failed", { cause })),
+          Effect.forkScoped,
+          Effect.asVoid,
+        )
+        yield* reconciler().pipe(
+          Effect.catchCause((cause) => Effect.logWarning("status reconciler failed", { cause })),
           Effect.forkScoped,
           Effect.asVoid,
         )

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -20,6 +20,7 @@ export interface Interface {
     work: Effect.Effect<MessageV2.WithParts>,
     ready?: Latch.Latch,
   ) => Effect.Effect<MessageV2.WithParts>
+  readonly reconcile: () => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionRunState") {}
@@ -101,7 +102,23 @@ export const layer = Layer.effect(
       return yield* (yield* runner(sessionID, onInterrupt)).startShell(work, ready)
     })
 
-    return Service.of({ assertNotBusy, cancel, ensureRunning, startShell })
+    // Reset statuses to idle for any session marked busy/retry without an actively-running
+    // runner. Guards against onIdle finalizers failing to fire (interrupted scope, etc.)
+    // and leaving clients seeing a session stuck as "working" indefinitely.
+    const reconcile = Effect.fn("SessionRunState.reconcile")(function* () {
+      const data = yield* InstanceState.get(state)
+      const statuses = yield* status.list()
+      for (const [sessionID, info] of statuses) {
+        if (info.type === "idle") continue
+        const existing = data.runners.get(sessionID)
+        if (existing?.busy) continue
+        yield* Effect.logInfo("reconciling stale session status", { sessionID, status: info.type })
+        if (existing) data.runners.delete(sessionID)
+        yield* status.set(sessionID, { type: "idle" })
+      }
+    })
+
+    return Service.of({ assertNotBusy, cancel, ensureRunning, startShell, reconcile })
   }),
 )
 

--- a/packages/opencode/test/session/reconcile.test.ts
+++ b/packages/opencode/test/session/reconcile.test.ts
@@ -1,0 +1,61 @@
+import { expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { SessionID } from "../../src/session/schema"
+import { SessionRunState } from "../../src/session/run-state"
+import { SessionStatus } from "../../src/session/status"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(
+  Layer.mergeAll(SessionStatus.defaultLayer, SessionRunState.defaultLayer, CrossSpawnSpawner.defaultLayer),
+)
+
+it.instance("reconcile resets a stale busy session with no active runner", () =>
+  Effect.gen(function* () {
+    const status = yield* SessionStatus.Service
+    const runState = yield* SessionRunState.Service
+    const sessionID = SessionID.make("reconcile_stale_busy")
+
+    yield* status.set(sessionID, { type: "busy" })
+    expect((yield* status.get(sessionID)).type).toBe("busy")
+
+    yield* runState.reconcile()
+
+    expect((yield* status.get(sessionID)).type).toBe("idle")
+  }),
+)
+
+it.instance("reconcile resets a stale retry session with no active runner", () =>
+  Effect.gen(function* () {
+    const status = yield* SessionStatus.Service
+    const runState = yield* SessionRunState.Service
+    const sessionID = SessionID.make("reconcile_stale_retry")
+
+    yield* status.set(sessionID, {
+      type: "retry",
+      attempt: 3,
+      message: "rate limited",
+      next: Date.now() + 60_000,
+    })
+    expect((yield* status.get(sessionID)).type).toBe("retry")
+
+    yield* runState.reconcile()
+
+    expect((yield* status.get(sessionID)).type).toBe("idle")
+  }),
+)
+
+it.instance("reconcile leaves idle sessions unchanged", () =>
+  Effect.gen(function* () {
+    const status = yield* SessionStatus.Service
+    const runState = yield* SessionRunState.Service
+    const sessionID = SessionID.make("reconcile_idle")
+
+    // an idle status has no entry in the map; reconcile() should still complete cleanly
+    expect((yield* status.get(sessionID)).type).toBe("idle")
+
+    yield* runState.reconcile()
+
+    expect((yield* status.get(sessionID)).type).toBe("idle")
+  }),
+)


### PR DESCRIPTION
### Issue for this PR

Closes #220

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a runner's \`onIdle\` finalizer fails to fire (interrupted scope, lost fiber), \`SessionStatus\` stays \`busy\` indefinitely while no runner is actually executing. Clients see the session stuck as \"working\" until the process restarts. \`SessionRunState.cancel\` already has the same \"no busy runner → set idle\" defensive check (\`run-state.ts:80\`) but it only fires on explicit cancel.

This adds the same check as a passive reconciliation:

- **\`SessionRunState.reconcile()\`** — scans \`SessionStatus.list()\`, drops orphan map entries, and resets every non-idle status without a busy runner to \`idle\`.
- **\`serve-reconciler.ts\`** — iterates known session directories via \`Session.listGlobal\`, enters each instance via \`InstanceStore.provide\`, calls \`runState.reconcile()\`. Uses the autoresume worker's pattern.
- **\`serve.ts\`** — forks the reconciler as a scoped fiber alongside the autoresume worker. Interval and scan limit configurable via \`OPENCODE_SERVE_RECONCILE_INTERVAL_S\` (default 30s) and \`OPENCODE_SERVE_RECONCILE_SCAN_LIMIT\` (default 100).
- Tests covering: stale \`busy\` → idle, stale \`retry\` → idle, idle untouched.

Ports the spirit of PR #208 (auto-closed by the template bot, not on merit) to the post-upstream-rebase Effect architecture. The original 3-file, ~107-LoC namespace patch couldn't cherry-pick because \`SessionPrompt\` is now a \`Context.Service\` and \`serve.ts\` is \`effectCmd\`; the new design lives on \`SessionRunState\` instead, where the status/runner consistency check already exists.

### How did you verify your code works?

- \`cd packages/opencode && bun test test/session/reconcile.test.ts\` → 3 pass, 0 fail.
- \`cd packages/opencode && bun typecheck\` → clean once #219 lands. (This branch is currently pre-push-blocked by the pre-existing typecheck error in \`src/tool/session.ts\` that #219 fixes; recommend merging #219 first.)
- Code path verified by reading: \`SessionRunState\` instance state, the \`runner.busy\` getter from \`effect/runner\`, and the \`InstanceStore.provide\` pattern already used by \`serve-autoresume.ts\`.

### Screenshots / recordings

N/A — server-side fix, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR