### PR TITLE
docs: record reconciler port and tool typecheck status

### DIFF
--- a/handoff.md
+++ b/handoff.md
@@ -11,6 +11,19 @@
   - `rebase-session` — done
   - `rebase-infra` — done
   - `rebase-verify` — in progress
+- Open PRs (post-rebase polish, awaiting CI / merge):
+  - **#219** `fix(tool): orDie session tool execute` — unblocks `bun typecheck` on `dev`. Closes #218.
+  - **#221** `fix(session): add periodic status reconciler` — Effect-native port of PR #208 (auto-closed by template bot, not on merit). Closes #220.
+  - Merge order: #219 first (clears pre-push typecheck hook), then #221.
+
+## Latest Update (2026-05-21)
+- Audited remaining fork branches against `origin/dev`; deleted superseded ones (`backup/dev-before-timeout-history-rewrite-20260430`, `feat/android-backbone-10288`, `opencode/opencode-2026-04-29-22-50`, `rewrite/dev-no-timeout`, `fix/computediff-and-serve-smoke`, `pr10624-local`, `fix/session-status-reconciliation`).
+- Ported the stale-busy-session reconciler (originally PR #208's `f62969219`) to the post-rebase Effect architecture:
+  - `SessionRunState.reconcile()` resets non-idle statuses without an active runner to idle.
+  - `cli/cmd/serve-reconciler.ts` forks a 30s scoped fiber, iterates known directories via `Session.listGlobal` + `InstanceStore.provide`. Env-tunable: `OPENCODE_SERVE_RECONCILE_INTERVAL_S`, `OPENCODE_SERVE_RECONCILE_SCAN_LIMIT`.
+  - Tests: `test/session/reconcile.test.ts` — 3 pass.
+- Found and fixed a pre-existing typecheck regression in `src/tool/session.ts` (`session.get` returns `Effect<Info, NotFound>` but `Tool.Def.execute` requires `Effect<ExecuteResult, never, never>`). Pattern-matched the codebase-wide fix used by every other tool: `.pipe(Effect.orDie)`.
+- Both PRs healthy: `MERGEABLE`, all bot template checks green (`check-standards`, `check-compliance`, `add-contributor-label`). CI workflows (`typecheck`, `unit`, `e2e`, `nix-eval`) are queued — self-hosted runner queue appears stuck.
 
 ## Latest Update (2026-05-09)
 - Rebased branch onto latest `upstream/dev` and resumed full verification.


### PR DESCRIPTION
### Issue for this PR

Closes #220

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Updates \`handoff.md\` to reflect the current state of post-rebase polish work:

- Adds open PRs (#219, #221) to the "Current State" block with the recommended merge order (#219 first, then #221).
- Adds a "Latest Update (2026-05-21)" section recording:
  - The branch audit + cleanup of seven superseded fork branches.
  - The reconciler port (PR #221) including the new \`SessionRunState.reconcile()\` method, the \`serve-reconciler\` fiber, env tunables, and 3 passing tests.
  - The pre-existing \`src/tool/session.ts\` typecheck regression and the codebase-pattern fix in #219.
  - A note that the bot template checks are green but the self-hosted runner queue is currently stuck.

Pure docs change — no source modifications.

### How did you verify your code works?

N/A — markdown only.

### Screenshots / recordings

N/A.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR