### PR TITLE
feat(workflow): bare-globals shim for Claude Code dynamic workflows

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -34,7 +34,7 @@ export const Info = Schema.Struct({
   description: Schema.optional(Schema.String),
   agent: Schema.optional(Schema.String),
   model: Schema.optional(Schema.String),
-  source: Schema.optional(Schema.Literals(["command", "mcp", "skill"])),
+  source: Schema.optional(Schema.Literals(["command", "mcp", "skill", "workflow"])),
   // Some command templates are lazy promises from MCP prompt resolution.
   template: Schema.Unknown.annotate({ [ZodOverride]: z.promise(z.string()).or(z.string()) }),
   subtask: Schema.optional(Schema.Boolean),
@@ -59,6 +59,7 @@ export function hints(template: string) {
 export const Default = {
   INIT: "init",
   REVIEW: "review",
+  WORKFLOW: "workflow",
 } as const
 
 export interface Interface {
@@ -98,6 +99,13 @@ export const layer = Layer.effect(
         },
         subtask: true,
         hints: hints(PROMPT_REVIEW),
+      }
+      commands[Default.WORKFLOW] = {
+        name: Default.WORKFLOW,
+        description: "run JS workflows from .opencode/workflows",
+        source: "workflow",
+        template: "",
+        hints: ["$ARGUMENTS"],
       }
 
       for (const [name, command] of Object.entries(cfg.command ?? {})) {

--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -467,13 +467,8 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
 
             // Capture reasoning_opaque for Copilot multi-turn reasoning
             if (delta.reasoning_opaque) {
-              if (reasoningOpaque != null) {
-                throw new InvalidResponseDataError({
-                  data: delta,
-                  message:
-                    "Multiple reasoning_opaque values received in a single response. Only one thinking part per response is supported.",
-                })
-              }
+              // Accept the latest reasoning_opaque value — Claude models may
+              // produce multiple thinking blocks on complex prompts.
               reasoningOpaque = delta.reasoning_opaque
             }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -419,7 +419,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         providerID: input.model.providerID,
         agent: input.agent,
       })) {
-        const schema = ProviderTransform.schema(input.model, EffectZod.toJsonSchema(item.parameters))
+        let schema: ReturnType<typeof ProviderTransform.schema>
+        try {
+          schema = ProviderTransform.schema(input.model, EffectZod.toJsonSchema(item.parameters))
+        } catch (err) {
+          log.warn("skipping tool with invalid parameters", { tool: item.id, error: String(err) })
+          continue
+        }
         tools[item.id] = tool({
           description: item.description,
           inputSchema: jsonSchema(schema),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -414,6 +414,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             .pipe(Effect.orDie),
       })
 
+      // When tools has wildcard disable ("*": false), skip all tool registration.
+      // This is used by workflow agent calls to get clean text completions.
+      if (input.tools?.["*"] === false) return tools
+
       for (const item of yield* registry.tools({
         modelID: ModelID.make(input.model.api.id),
         providerID: input.model.providerID,
@@ -1605,7 +1609,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               instruction.system().pipe(Effect.orDie),
               MessageV2.toModelMessagesEffect(msgs, model),
             ])
-            const system = [...env, ...instructions, ...(skills ? [skills] : [])]
+            // When a system override is set (e.g., workflow agent calls),
+            // use only that — skip AGENTS.md, skills, and full env prompt.
+            // Check the first user message (not lastUser) because subsequent
+            // loop iterations create new user messages for tool results that
+            // lack the system field.
+            const firstUserSystem = (msgs.find(m => m.info.role === "user") as { info: MessageV2.User } | undefined)?.info.system
+            const system = firstUserSystem
+              ? [firstUserSystem]
+              : [...env, ...instructions, ...(skills ? [skills] : [])]
             const format = lastUser.format ?? { type: "text" as const }
             if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
             const result = yield* handle.process({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -30,6 +30,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import * as Stream from "effect/Stream"
 import { Command } from "../command"
+import * as Workflow from "@/workflow"
 import { pathToFileURL, fileURLToPath } from "url"
 import { Config } from "@/config/config"
 import { ConfigMarkdown } from "@/config/markdown"
@@ -1667,7 +1668,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       },
     )
 
-    const command = Effect.fn("SessionPrompt.command")(function* (input: CommandInput) {
+    const command: Interface["command"] = (input) =>
+      Effect.gen(function* () {
       yield* elog.info("command", { sessionID: input.sessionID, command: input.command, agent: input.agent })
       const cmd = yield* commands.get(input.command)
       if (!cmd) {
@@ -1676,6 +1678,23 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         const error = new NamedError.Unknown({ message: `Command not found: "${input.command}".${hint}` })
         yield* bus.publish(Session.Event.Error, { sessionID: input.sessionID, error: error.toObject() })
         throw error
+      }
+      if (cmd.source === "workflow") {
+        return yield* Workflow.executeCommand({
+          sessionID: input.sessionID,
+          messageID: input.messageID,
+          arguments: input.arguments,
+          agent: input.agent,
+          model: input.model,
+          variant: input.variant,
+        }).pipe(
+          Effect.provideService(Session.Service, sessions),
+          Effect.provideService(Agent.Service, agents),
+          Effect.provideService(Provider.Service, provider),
+          Effect.provideService(Config.Service, config),
+          Effect.provideService(Plugin.Service, plugin),
+          Effect.provideService(ToolRegistry.Service, registry),
+        )
       }
       const agentName = cmd.agent ?? input.agent ?? (yield* agents.defaultAgent())
 

--- a/packages/opencode/src/workflow/index.ts
+++ b/packages/opencode/src/workflow/index.ts
@@ -369,6 +369,7 @@ const executeLoaded = Effect.fn("Workflow.executeLoaded")(function* (input: {
   const config = yield* Config.Service
   const registry = yield* ToolRegistry.Service
   const agents = yield* Agent.Service
+  const provider = yield* Provider.Service
   const ctx = yield* InstanceState.context
   const logs: string[] = []
   let phase: string | undefined
@@ -444,10 +445,29 @@ const executeLoaded = Effect.fn("Workflow.executeLoaded")(function* (input: {
                 filename: path.basename(file),
                 mime: "text/plain",
               })) ?? []
+            // Resolve model: "provider/model" uses parseModel directly;
+            // bare "model-name" searches all configured providers.
+            let resolvedModel: ReturnType<typeof Provider.parseModel> | undefined
+            if (options.model) {
+              if (options.model.includes("/")) {
+                resolvedModel = Provider.parseModel(options.model)
+              } else {
+                const providers = yield* provider.list()
+                for (const [pid, info] of Object.entries(providers)) {
+                  if (options.model in info.models) {
+                    resolvedModel = Provider.parseModel(`${pid}/${options.model}`)
+                    break
+                  }
+                }
+                if (!resolvedModel) {
+                  resolvedModel = Provider.parseModel(options.model)
+                }
+              }
+            }
             return yield* promptSvc.prompt({
               sessionID: child.id,
               agent: options.agent ?? (yield* agents.defaultAgent()),
-              model: options.model ? Provider.parseModel(options.model) : undefined,
+              model: resolvedModel,
               variant: options.variant,
               format: options.schema
                 ? new MessageV2.OutputFormatJsonSchema({ type: "json_schema", schema: options.schema })

--- a/packages/opencode/src/workflow/index.ts
+++ b/packages/opencode/src/workflow/index.ts
@@ -424,6 +424,8 @@ const executeLoaded = Effect.fn("Workflow.executeLoaded")(function* (input: {
       variant?: string
       files?: string[]
       schema?: Record<string, unknown>
+      system?: string
+      tools?: boolean
       onError?: "fail" | "null"
     }) => {
       try {
@@ -437,7 +439,8 @@ const executeLoaded = Effect.fn("Workflow.executeLoaded")(function* (input: {
         const result = await run(
           Effect.gen(function* () {
             const promptSvc = yield* SessionPrompt.Service
-            const parts = yield* promptSvc.resolvePromptParts(options.prompt)
+            const resolvedParts = yield* promptSvc.resolvePromptParts(options.prompt)
+            const parts: Array<{ type: string; text?: string; url?: string; filename?: string; mime?: string; id?: string }> = [...resolvedParts]
             const attachments =
               options.files?.map((file) => ({
                 type: "file" as const,
@@ -447,6 +450,9 @@ const executeLoaded = Effect.fn("Workflow.executeLoaded")(function* (input: {
               })) ?? []
             // Resolve model: "provider/model" uses parseModel directly;
             // bare "model-name" searches all configured providers.
+            // Prefers the highest-versioned match (e.g., "claude-sonnet-4" →
+            // "claude-sonnet-4.6" over exact "claude-sonnet-4" which may be
+            // deprecated or unsupported by the API).
             let resolvedModel: ReturnType<typeof Provider.parseModel> | undefined
             if (options.model) {
               if (options.model.includes("/")) {
@@ -454,8 +460,18 @@ const executeLoaded = Effect.fn("Workflow.executeLoaded")(function* (input: {
               } else {
                 const providers = yield* provider.list()
                 for (const [pid, info] of Object.entries(providers)) {
-                  if (options.model in info.models) {
-                    resolvedModel = Provider.parseModel(`${pid}/${options.model}`)
+                  const modelKeys = Object.keys(info.models)
+                  // Find all models that start with the requested name
+                  const matches = modelKeys.filter(k =>
+                    k === options.model || k.startsWith(options.model + ".") || k.startsWith(options.model + "-")
+                  )
+                  if (matches.length > 0) {
+                    // Prefer versioned variants (e.g., claude-sonnet-4.6) over
+                    // the bare name (claude-sonnet-4) — bare names are often
+                    // aliases that rotate and may be temporarily unsupported.
+                    const versioned = matches.filter(k => k !== options.model)
+                    const best = versioned.length > 0 ? versioned.sort().pop()! : matches[0]
+                    resolvedModel = Provider.parseModel(`${pid}/${best}`)
                     break
                   }
                 }
@@ -464,20 +480,88 @@ const executeLoaded = Effect.fn("Workflow.executeLoaded")(function* (input: {
                 }
               }
             }
-            return yield* promptSvc.prompt({
+            // When schema is specified, embed the schema in the prompt and parse
+            // JSON from the text response. This avoids the StructuredOutput tool
+            // which conflicts with extended-thinking models (toolChoice: required
+            // is incompatible with thinking/reasoning).
+            if (options.schema) {
+              const schemaInstruction = [
+                "\n\nYou MUST respond with ONLY a valid JSON object matching this schema:",
+                "```json",
+                JSON.stringify(options.schema, null, 2),
+                "```",
+                "Do not include any other text, explanation, or markdown. Output ONLY the JSON object.",
+              ].join("\n")
+              const lastTextPart = [...parts].reverse().find(p => p.type === "text")
+              if (lastTextPart && "text" in lastTextPart && lastTextPart.text) {
+                (lastTextPart as { text: string }).text += schemaInstruction
+              } else {
+                parts.push({ type: "text", text: schemaInstruction })
+              }
+            }
+            // Override system prompt to a minimal instruction — the default
+            // agent's full system prompt (with tool docs, persona, etc.)
+            // confuses the model on workflow-specific prompts.
+            // Tools disabled by default for clean text completions. Workflows
+            // needing file access can pass { tools: true } in agent options.
+            const agentName = options.agent ?? (yield* agents.defaultAgent())
+            const enableTools = options.tools === true
+            const systemPrompt = options.system ?? "You are a helpful assistant. Follow the user's instructions precisely. If asked to output JSON, output ONLY valid JSON with no other text."
+            let promptResult = yield* promptSvc.prompt({
               sessionID: child.id,
-              agent: options.agent ?? (yield* agents.defaultAgent()),
-              model: resolvedModel,
-              variant: options.variant,
-              format: options.schema
-                ? new MessageV2.OutputFormatJsonSchema({ type: "json_schema", schema: options.schema })
-                : undefined,
-              parts: [...parts, ...attachments],
+              agent: agentName,
+              variant: options.variant ?? "low",
+              system: systemPrompt,
+              ...(!enableTools ? { tools: { "*": false } } : {}),
+              parts: [...parts, ...attachments] as any,
             })
+            // If schema was requested but model returned empty text (common when
+            // tools were used — model gathers info then stops without outputting),
+            // send a follow-up message asking for the JSON output.
+            const firstText = lastText(promptResult)
+            if (options.schema && !firstText.trim()) {
+              const followUp: MessageV2.TextPartInput = {
+                type: "text",
+                text: "Now produce your final answer as a JSON object matching the schema. Output ONLY the JSON, no other text.",
+              }
+              promptResult = yield* promptSvc.prompt({
+                sessionID: child.id,
+                agent: agentName,
+                variant: options.variant ?? "low",
+                system: systemPrompt,
+                tools: { "*": false },
+                parts: [followUp],
+              })
+            }
+            // Check for API/model errors on the assistant message
+            const info = promptResult.info
+            if (info.role === "assistant" && info.error) {
+              const errData = info.error as Record<string, unknown>
+              const errMsg = (errData.data as Record<string, unknown>)?.message ?? errData.message ?? "Unknown provider error"
+              throw new Error(`Agent call failed: ${errMsg}`)
+            }
+            return promptResult
           }),
         )
         const text = lastText(result)
-        return { text, data: result.info.role === "assistant" ? result.info.structured ?? text : text }
+        // For schema requests, parse JSON from the text response
+        let data: unknown = text
+        if (options.schema && text) {
+          try {
+            // Strip markdown code fences and surrounding whitespace
+            const cleaned = text.trim()
+              .replace(/^```(?:json)?\s*\n?/i, "")
+              .replace(/\n?```\s*$/i, "")
+              .trim()
+            data = JSON.parse(cleaned)
+          } catch {
+            data = text
+          }
+        } else if (result.info.role === "assistant") {
+          data = result.info.structured ?? text
+        }
+        logs.push(`[workflow:agent] text=${text.length}chars data=${typeof data} role=${result.info.role} parts=${result.parts.length}`)
+        return { text, data }
       } catch (error) {
         if (options.onError === "null") return null
         throw error

--- a/packages/opencode/src/workflow/index.ts
+++ b/packages/opencode/src/workflow/index.ts
@@ -75,7 +75,81 @@ function parseArgs(input: string, info?: Info) {
   )
 }
 
+// Claude Code "bare globals" format: file exports `meta` but no `run()`.
+// The file body uses top-level await with injected globals: agent(), parallel(),
+// phase(), log(), and args. We wrap it in an AsyncFunction and bridge the
+// globals to WorkflowContext methods.
+async function importBareGlobals(file: string): Promise<WorkflowDefinition | undefined> {
+  const source = await fs.readFile(file, "utf8")
+  if (!source.includes("export const meta")) return undefined
+
+  // Extract meta object using brace counting
+  const metaMatch = source.match(/export\s+const\s+meta\s*=\s*\{/)
+  if (!metaMatch || metaMatch.index === undefined) return undefined
+  const braceOpen = metaMatch.index + metaMatch[0].length - 1
+  let depth = 0
+  let metaEnd = -1
+  for (let i = braceOpen; i < source.length; i++) {
+    if (source[i] === "{") depth++
+    else if (source[i] === "}") {
+      depth--
+      if (depth === 0) {
+        metaEnd = i + 1
+        break
+      }
+    }
+  }
+  if (metaEnd === -1) return undefined
+
+  const metaSource = source.slice(braceOpen, metaEnd)
+  let meta: Meta
+  try {
+    meta = new Function("return " + metaSource)() as Meta
+  } catch {
+    return undefined
+  }
+  if (!meta?.name) return undefined
+
+  // Build body: strip meta declaration and export keywords
+  const body = (source.slice(0, metaMatch.index) + source.slice(metaEnd))
+    .replace(/^export\s+/gm, "")
+    .trim()
+
+  const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (...args: string[]) => (...injected: unknown[]) => Promise<unknown>
+  let fn: (...injected: unknown[]) => Promise<unknown>
+  try {
+    fn = new AsyncFunction("args", "agent", "parallel", "phase", "log", body)
+  } catch (err) {
+    throw new Error(`Failed to compile bare-globals workflow ${file}: ${err instanceof Error ? err.message : String(err)}`)
+  }
+
+  return {
+    meta,
+    run: async (args: Record<string, unknown>, ctx: WorkflowContext) => {
+      const agentFn = async (prompt: string, options?: Record<string, unknown>) => {
+        const input: Parameters<WorkflowContext["agent"]>[0] = { prompt }
+        if (options?.model) input.model = options.model as string
+        if (options?.schema) input.schema = options.schema as Record<string, unknown>
+        if (options?.agent) input.agent = options.agent as string
+        if (options?.variant) input.variant = options.variant as string
+        if (options?.files) input.files = options.files as string[]
+        if (options?.onError) input.onError = options.onError as "fail" | "null"
+        const result = await ctx.agent(input)
+        // Claude Code agent() returns structured data directly, not {text, data}
+        if (!result) return null
+        if (result.data !== undefined && result.data !== null && result.data !== "") return result.data
+        return result.text
+      }
+      return fn(args, agentFn, ctx.parallel.bind(ctx), ctx.setPhase.bind(ctx), ctx.log.bind(ctx))
+    },
+  }
+}
+
 async function importWorkflow(file: string) {
+  // Try bare-globals format first (Claude Code dynamic workflows)
+  const bareGlobals = await importBareGlobals(file)
+  if (bareGlobals) return bareGlobals
+
   const url = pathToFileURL(file)
   url.searchParams.set("t", String(Date.now()))
   const mod = await import(url.href)
@@ -103,7 +177,13 @@ const load = Effect.fn("Workflow.load")(function* () {
   // cached from before the project .opencode dir existed (e.g. in tests or when
   // the dir is created after first config access).
   const directories = [
-    ...new Set([path.join(ctx.directory, ".opencode"), path.join(ctx.worktree, ".opencode"), ...configDirs]),
+    ...new Set([
+      path.join(ctx.directory, ".opencode"),
+      path.join(ctx.worktree, ".opencode"),
+      path.join(ctx.directory, ".agents"),
+      path.join(ctx.worktree, ".agents"),
+      ...configDirs,
+    ]),
   ]
   const seen = new Set<string>()
   const result: LoadedWorkflow[] = []

--- a/packages/opencode/src/workflow/index.ts
+++ b/packages/opencode/src/workflow/index.ts
@@ -1,0 +1,500 @@
+import path from "path"
+import fs from "fs/promises"
+import { pathToFileURL } from "url"
+import type { WorkflowContext, WorkflowDefinition } from "@opencode-ai/plugin"
+import { Global } from "@opencode-ai/core/global"
+import { Glob } from "@opencode-ai/core/util/glob"
+import { Agent } from "@/agent/agent"
+import { Config } from "@/config/config"
+import { EffectBridge } from "@/effect/bridge"
+import { InstanceState } from "@/effect/instance-state"
+import { Plugin } from "@/plugin"
+import { Provider } from "@/provider/provider"
+import { MessageV2 } from "@/session/message-v2"
+import { Session } from "@/session/session"
+import { MessageID, PartID, SessionID } from "@/session/schema"
+import { ToolRegistry } from "@/tool/registry"
+import * as Process from "@/util/process"
+import { Effect } from "effect"
+
+type ArgumentInfo = {
+  type?: "string" | "number" | "boolean"
+  default?: unknown
+  description?: string
+}
+
+type Meta = {
+  name: string
+  description?: string
+  whenToUse?: string
+  phases?: readonly (string | { title: string; detail?: string; model?: string })[]
+  arguments?: Record<string, ArgumentInfo>
+}
+
+type LoadedWorkflow = {
+  path: string
+  meta: Meta
+  run: WorkflowDefinition["run"]
+}
+
+export type Info = {
+  name: string
+  description?: string
+  whenToUse?: string
+  path: string
+  arguments?: Record<string, ArgumentInfo>
+  phases?: readonly (string | { title: string; detail?: string; model?: string })[]
+}
+
+function lastText(message: MessageV2.WithParts) {
+  return message.parts.findLast((part) => part.type === "text")?.text ?? ""
+}
+
+function parseArgs(input: string, info?: Info) {
+  const trimmed = input.trim()
+  if (!trimmed) return {}
+  if (trimmed.startsWith("{")) return JSON.parse(trimmed) as Record<string, unknown>
+  const entries = trimmed
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((item) => {
+      const index = item.indexOf("=")
+      if (index === -1) return [item, true] as const
+      return [item.slice(0, index), item.slice(index + 1)] as const
+    })
+  if (info?.arguments && Object.keys(info.arguments).length === 1 && entries.length === 1 && entries[0][1] === true) {
+    return { [Object.keys(info.arguments)[0]]: entries[0][0] }
+  }
+  return Object.fromEntries(
+    entries.map(([key, value]) => {
+      if (value === true || value === "true") return [key, true]
+      if (value === "false") return [key, false]
+      const numeric = Number(value)
+      return [key, Number.isFinite(numeric) && value.trim() !== "" ? numeric : value]
+    }),
+  )
+}
+
+async function importWorkflow(file: string) {
+  const url = pathToFileURL(file)
+  url.searchParams.set("t", String(Date.now()))
+  const mod = await import(url.href)
+  const workflow = mod.default
+  if (!workflow || typeof workflow !== "object" || typeof workflow.run !== "function" || !workflow.meta?.name) {
+    throw new Error(`Workflow ${file} must export default workflow({...})`)
+  }
+  return workflow as WorkflowDefinition
+}
+
+const materializePluginWorkflow = Effect.fn("Workflow.materializePlugin")(function* (name: string, source: string) {
+  const dir = path.join(Global.Path.config, "workflows")
+  yield* Effect.promise(() => fs.mkdir(dir, { recursive: true }))
+  const file = path.join(dir, `plugin-${name.replace(/[^a-zA-Z0-9_-]/g, "_")}.ts`)
+  yield* Effect.promise(() => fs.writeFile(file, source))
+  return file
+})
+
+const load = Effect.fn("Workflow.load")(function* () {
+  const config = yield* Config.Service
+  const plugin = yield* Plugin.Service
+  const ctx = yield* InstanceState.context
+  const directories = [...new Set([path.join(ctx.worktree, ".opencode"), ...(yield* config.directories())])]
+  const seen = new Set<string>()
+  const result: LoadedWorkflow[] = []
+
+  for (const dir of directories) {
+    for (const pattern of ["workflows/*.ts", "workflows/*.js", "workflows/*.mts", "workflows/*.mjs"]) {
+      for (const file of yield* Effect.promise(() => Glob.scan(pattern, { cwd: dir, absolute: true, dot: true, symlink: false }))) {
+        const workflow = yield* Effect.promise(() => importWorkflow(file))
+        if (seen.has(workflow.meta.name)) continue
+        seen.add(workflow.meta.name)
+        result.push({ path: file, meta: workflow.meta, run: workflow.run })
+      }
+    }
+  }
+
+  for (const hooks of yield* plugin.list()) {
+    const workflows = yield* Effect.promise(() => hooks.workflow?.() ?? Promise.resolve(undefined))
+    if (!workflows) continue
+    for (const [name, item] of Object.entries(workflows)) {
+      if (seen.has(name)) continue
+      const workflow =
+        typeof item === "string"
+          ? yield* Effect.promise(() =>
+              materializePluginWorkflow(name, item).pipe(
+                Effect.flatMap((file) => Effect.promise(() => importWorkflow(file))),
+                Effect.runPromise,
+              ),
+            )
+          : item
+      seen.add(name)
+      result.push({ path: `plugin:${name}`, meta: workflow.meta, run: workflow.run })
+    }
+  }
+
+  return result
+})
+
+export const list = Effect.fn("Workflow.list")(function* () {
+  return (yield* load()).map((item) => ({
+    name: item.meta.name,
+    description: item.meta.description,
+    whenToUse: item.meta.whenToUse,
+    path: item.path,
+    arguments: item.meta.arguments,
+    phases: item.meta.phases,
+  }))
+})
+
+const getByName = Effect.fn("Workflow.getByName")(function* (name: string) {
+  return (yield* load()).find((item) => item.meta.name === name)
+})
+
+function renderList(items: Info[]) {
+  if (items.length === 0) return "No workflows found. Create .opencode/workflows/<name>.ts and export default workflow({...})."
+  return [
+    "Available workflows:",
+    ...items.map((item) => {
+      const args = item.arguments ? ` args: ${Object.keys(item.arguments).join(", ")}` : ""
+      return `- ${item.name}${item.description ? ` — ${item.description}` : ""}${args}`
+    }),
+    "",
+    "Run one with: /workflow <name> key=value",
+  ].join("\n")
+}
+
+function renderResult(name: string, logs: string[], result: unknown) {
+  const output =
+    typeof result === "string"
+      ? result
+      : result === undefined
+        ? ""
+        : JSON.stringify(result, null, 2)
+  const sections = [`Workflow ${name} complete.`]
+  if (output) sections.push(output)
+  if (logs.length > 0) sections.push(["Logs:", ...logs.map((item) => `- ${item}`)].join("\n"))
+  return sections.join("\n\n")
+}
+
+const createUserMessage = Effect.fn("Workflow.createUserMessage")(function* (input: {
+  sessionID: SessionID
+  command: string
+  messageID?: MessageID
+  agent?: string
+  model?: string
+  variant?: string
+}) {
+  const sessions = yield* Session.Service
+  const agents = yield* Agent.Service
+  const providers = yield* Provider.Service
+  const session = yield* sessions.get(input.sessionID)
+  const agent = input.agent ?? session.agent ?? (yield* agents.defaultAgent())
+  const baseModel = input.model ? Provider.parseModel(input.model) : (session.model ?? (yield* providers.defaultModel()))
+  const modelID = "id" in baseModel ? baseModel.id : baseModel.modelID
+  const variant = "variant" in baseModel ? baseModel.variant : undefined
+  const info: MessageV2.User = {
+    id: input.messageID ?? MessageID.ascending(),
+    sessionID: input.sessionID,
+    role: "user",
+    time: { created: Date.now() },
+    agent,
+    model: {
+      providerID: baseModel.providerID,
+      modelID,
+      variant: input.variant ?? variant,
+    },
+  }
+  yield* sessions.updateMessage(info)
+  const part: MessageV2.TextPart = {
+    id: PartID.ascending(),
+    messageID: info.id,
+    sessionID: input.sessionID,
+    type: "text",
+    text: input.command,
+  }
+  yield* sessions.updatePart(part)
+  return { info, parts: [part] }
+})
+
+const createAssistantMessage = Effect.fn("Workflow.createAssistantMessage")(function* (input: {
+  sessionID: SessionID
+  parent: MessageV2.User
+  text: string
+  structured?: unknown
+}) {
+  const sessions = yield* Session.Service
+  const ctx = yield* InstanceState.context
+  const info: MessageV2.Assistant = {
+    id: MessageID.ascending(),
+    sessionID: input.sessionID,
+    parentID: input.parent.id,
+    role: "assistant",
+    time: { created: Date.now(), completed: Date.now() },
+    modelID: input.parent.model.modelID,
+    providerID: input.parent.model.providerID,
+    mode: input.parent.agent,
+    agent: input.parent.agent,
+    path: { cwd: ctx.directory, root: ctx.worktree },
+    summary: false,
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    structured: input.structured,
+    variant: input.parent.model.variant,
+  }
+  yield* sessions.updateMessage(info)
+  const part: MessageV2.TextPart = {
+    id: PartID.ascending(),
+    messageID: info.id,
+    sessionID: input.sessionID,
+    type: "text",
+    text: input.text,
+  }
+  yield* sessions.updatePart(part)
+  return { info, parts: [part] }
+})
+
+function withConcurrency<T, R>(items: readonly T[], limit: number, fn: (item: T, index: number) => Promise<R>) {
+  if (items.length === 0) return Promise.resolve([] as R[])
+  const results = Array.from({ length: items.length }) as R[]
+  const queue = [...items]
+  let index = 0
+  return Promise.all(
+    Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, async () => {
+      while (queue.length > 0) {
+        const item = queue.shift()
+        if (item === undefined) return
+        const current = index++
+        results[current] = await fn(item, current)
+      }
+    }),
+  ).then(() => results)
+}
+
+const executeLoaded = Effect.fn("Workflow.executeLoaded")(function* (input: {
+  workflow: LoadedWorkflow
+  args: Record<string, unknown>
+  sessionID: SessionID
+  messageID: MessageID
+  agent: string
+  depth?: number
+}) {
+  const bridge = yield* EffectBridge.make()
+  const sessions = yield* Session.Service
+  const config = yield* Config.Service
+  const registry = yield* ToolRegistry.Service
+  const agents = yield* Agent.Service
+  const ctx = yield* InstanceState.context
+  const logs: string[] = []
+  let phase: string | undefined
+  const run = <A, E, R>(effect: Effect.Effect<A, E, R>) => bridge.promise(effect)
+  const workflowCtx: WorkflowContext = {
+    budgetRemaining: Infinity,
+    budget: {
+      total: null,
+      spent: () => 0,
+      remaining: () => Infinity,
+      tokensTotal: null,
+      tokensSpent: () => 0,
+      tokensRemaining: () => Infinity,
+    },
+    setPhase(next: string) {
+      phase = next
+    },
+    log(message: string) {
+      logs.push(phase ? `[${phase}] ${message}` : message)
+    },
+    parallel: <T>(tasks: readonly (() => Promise<T>)[], options?: { concurrencyLimit?: number }) =>
+      withConcurrency(tasks, options?.concurrencyLimit ?? (tasks.length || 1), async (task) => {
+        try {
+          return await task()
+        } catch {
+          return null
+        }
+      }) as Promise<(T | null)[]>,
+    pipeline: async (items: readonly unknown[], ...rest: unknown[]) => {
+      const last = rest.at(-1)
+      const options =
+        last && typeof last === "object" && "concurrencyLimit" in (last as Record<string, unknown>)
+          ? (rest.pop() as { concurrencyLimit?: number })
+          : undefined
+      const stages = rest as Array<(prev: unknown, item: unknown, index: number) => Promise<unknown>>
+      return withConcurrency(items, options?.concurrencyLimit ?? (items.length || 1), async (item, index) => {
+        let previous: unknown = item
+        for (const stage of stages) {
+          try {
+            previous = await stage(previous, item, index)
+          } catch {
+            return null
+          }
+        }
+        return previous
+      })
+    },
+    agent: async (options: {
+      prompt: string
+      agent?: string
+      model?: string
+      variant?: string
+      files?: string[]
+      schema?: Record<string, unknown>
+      onError?: "fail" | "null"
+    }) => {
+      try {
+        const { SessionPrompt } = await import("@/session/prompt")
+        const child = await run(
+          sessions.create({
+            parentID: input.sessionID,
+            title: `${input.workflow.meta.name}: ${options.agent ?? "step"}`,
+          }),
+        )
+        const result = await run(
+          Effect.gen(function* () {
+            const promptSvc = yield* SessionPrompt.Service
+            const parts = yield* promptSvc.resolvePromptParts(options.prompt)
+            const attachments =
+              options.files?.map((file) => ({
+                type: "file" as const,
+                url: pathToFileURL(path.isAbsolute(file) ? file : path.join(ctx.directory, file)).href,
+                filename: path.basename(file),
+                mime: "text/plain",
+              })) ?? []
+            return yield* promptSvc.prompt({
+              sessionID: child.id,
+              agent: options.agent ?? (yield* agents.defaultAgent()),
+              model: options.model ? Provider.parseModel(options.model) : undefined,
+              variant: options.variant,
+              format: options.schema
+                ? new MessageV2.OutputFormatJsonSchema({ type: "json_schema", schema: options.schema })
+                : undefined,
+              parts: [...parts, ...attachments],
+            })
+          }),
+        )
+        const text = lastText(result)
+        return { text, data: result.info.role === "assistant" ? result.info.structured ?? text : text }
+      } catch (error) {
+        if (options.onError === "null") return null
+        throw error
+      }
+    },
+    tool: (async (name: string, args?: Record<string, unknown>, options?: { onError?: "fail" | "null" }) => {
+      try {
+        const tool = (await run(registry.all())).find((item) => item.id === name)
+        if (!tool) throw new Error(`Unknown tool: ${name}`)
+        const messages = await run(sessions.messages({ sessionID: input.sessionID }))
+        const result = await run(
+          tool.execute(args ?? {}, {
+            sessionID: input.sessionID,
+            messageID: input.messageID,
+            agent: input.agent,
+            abort: new AbortController().signal,
+            messages,
+            ask: () => Effect.void,
+            metadata: () => Effect.void,
+          }),
+        )
+        return { output: result.output, metadata: result.metadata }
+      } catch (error) {
+        if (options?.onError === "null") return null
+        throw error
+      }
+    }) as WorkflowContext["tool"],
+    shell: async (command: string, options?: { timeout?: number; cwd?: string }) => {
+      const shell = (await run(config.get())).shell
+      const result = await Process.text([command], {
+        shell: shell ?? true,
+        cwd: options?.cwd ?? ctx.directory,
+        timeout: options?.timeout,
+        nothrow: true,
+      })
+      return { output: result.text, exitCode: result.code }
+    },
+    workflow: async (name: string, args?: Record<string, unknown>) => {
+      if ((input.depth ?? 0) >= 1) throw new Error("Nested workflows are limited to depth 1")
+      const workflow = await run(getByName(name))
+      if (!workflow) throw new Error(`Workflow not found: ${name}`)
+      const nested = await run(
+        executeLoaded({
+          workflow,
+          args: args ?? {},
+          sessionID: input.sessionID,
+          messageID: input.messageID,
+          agent: input.agent,
+          depth: (input.depth ?? 0) + 1,
+        }),
+      )
+      return nested.result
+    },
+    question: async (options: { question: string }) => {
+      throw new Error(`Workflow questions not supported yet: ${options.question}`)
+    },
+  }
+  const result = yield* Effect.promise(() => input.workflow.run(input.args, workflowCtx))
+  return { logs, result }
+})
+
+const executeCommandRaw = Effect.fn("Workflow.executeCommand")(function* (input: {
+  sessionID: SessionID
+  messageID?: MessageID
+  arguments: string
+  agent?: string
+  model?: string
+  variant?: string
+}) {
+  const trimmed = input.arguments.trim()
+  const user = yield* createUserMessage({
+    sessionID: input.sessionID,
+    messageID: input.messageID,
+    command: `/workflow${trimmed ? ` ${trimmed}` : ""}`,
+    agent: input.agent,
+    model: input.model,
+    variant: input.variant,
+  })
+  if (!trimmed) {
+    return yield* createAssistantMessage({
+      sessionID: input.sessionID,
+      parent: user.info,
+      text: renderList(yield* list()),
+    })
+  }
+  const [name, ...rest] = trimmed.split(/\s+/)
+  const workflow = yield* getByName(name)
+  if (!workflow) {
+    const available = (yield* list()).map((item) => item.name).join(", ")
+    return yield* createAssistantMessage({
+      sessionID: input.sessionID,
+      parent: user.info,
+      text: available ? `Workflow not found: ${name}\nAvailable: ${available}` : `Workflow not found: ${name}`,
+    })
+  }
+  const info: Info = {
+    name: workflow.meta.name,
+    description: workflow.meta.description,
+    whenToUse: workflow.meta.whenToUse,
+    path: workflow.path,
+    arguments: workflow.meta.arguments,
+    phases: workflow.meta.phases,
+  }
+  const executed = yield* executeLoaded({
+    workflow,
+    args: parseArgs(rest.join(" "), info),
+    sessionID: input.sessionID,
+    messageID: user.info.id,
+    agent: user.info.agent,
+  })
+  return yield* createAssistantMessage({
+    sessionID: input.sessionID,
+    parent: user.info,
+    text: renderResult(workflow.meta.name, executed.logs, executed.result),
+    structured: typeof executed.result === "object" ? executed.result : undefined,
+  })
+})
+
+export const executeCommand = (input: {
+  sessionID: SessionID
+  messageID?: MessageID
+  arguments: string
+  agent?: string
+  model?: string
+  variant?: string
+}) => executeCommandRaw(input).pipe(Effect.orDie)

--- a/packages/opencode/src/workflow/index.ts
+++ b/packages/opencode/src/workflow/index.ts
@@ -98,7 +98,13 @@ const load = Effect.fn("Workflow.load")(function* () {
   const config = yield* Config.Service
   const plugin = yield* Plugin.Service
   const ctx = yield* InstanceState.context
-  const directories = [...new Set([path.join(ctx.worktree, ".opencode"), ...(yield* config.directories())])]
+  const configDirs = yield* config.directories()
+  // Always include ctx.directory/.opencode directly — config.directories() may be
+  // cached from before the project .opencode dir existed (e.g. in tests or when
+  // the dir is created after first config access).
+  const directories = [
+    ...new Set([path.join(ctx.directory, ".opencode"), path.join(ctx.worktree, ".opencode"), ...configDirs]),
+  ]
   const seen = new Set<string>()
   const result: LoadedWorkflow[] = []
 

--- a/packages/opencode/test/server/httpapi-workflow.test.ts
+++ b/packages/opencode/test/server/httpapi-workflow.test.ts
@@ -1,0 +1,165 @@
+// E2E test for the /workflow slash command via the HTTP API.
+//
+// Tests that a workflow file placed in .opencode/workflows/ can be:
+//   1. listed via POST /session/:id/command { command: "workflow", arguments: "" }
+//   2. executed via POST /session/:id/command { command: "workflow", arguments: "<name> [args]" }
+//
+// No LLM is required — the test workflow only calls ctx.log() and returns a string.
+
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { fileURLToPath } from "url"
+import { Effect } from "effect"
+import { WithInstance } from "../../src/project/with-instance"
+import { Server } from "../../src/server/server"
+import { Session as SessionNs } from "@/session/session"
+import type { SessionID } from "../../src/session/schema"
+import * as Log from "@opencode-ai/core/util/log"
+import { disposeAllInstances, tmpdir } from "../fixture/fixture"
+
+void Log.init({ print: false })
+
+// Resolve @opencode-ai/plugin from the workspace symlink — machine-independent.
+const PLUGIN_DIR = fileURLToPath(import.meta.resolve("@opencode-ai/plugin"))
+
+function run<A, E>(fx: Effect.Effect<A, E, SessionNs.Service>) {
+  return Effect.runPromise(fx.pipe(Effect.provide(SessionNs.defaultLayer)))
+}
+
+const svc = {
+  create(input?: SessionNs.CreateInput) {
+    return run(SessionNs.Service.use((s) => s.create(input)))
+  },
+  remove(id: SessionID) {
+    return run(SessionNs.Service.use((s) => s.remove(id)))
+  },
+}
+
+afterEach(async () => {
+  mock.restore()
+  await disposeAllInstances()
+})
+
+async function setupWorkflow(dir: string) {
+  const opencodeDir = path.join(dir, ".opencode")
+  const workflowDir = path.join(opencodeDir, "workflows")
+  const pluginLink = path.join(opencodeDir, "node_modules", "@opencode-ai", "plugin")
+
+  await fs.mkdir(workflowDir, { recursive: true })
+  await fs.mkdir(path.dirname(pluginLink), { recursive: true })
+  await fs.symlink(PLUGIN_DIR, pluginLink, "dir")
+
+  await Bun.write(
+    path.join(workflowDir, "greet.ts"),
+    [
+      'import { workflow } from "@opencode-ai/plugin"',
+      "",
+      "export default workflow({",
+      '  name: "greet",',
+      '  description: "greeter workflow",',
+      "  arguments: { name: { type: 'string', description: 'name to greet' } },",
+      "  async run(args, ctx) {",
+      '    ctx.log(`greeting name=${String(args.name ?? "")}`)' ,
+      "    return `Hello, ${String(args.name ?? 'world')}!`",
+      "  },",
+      "})",
+    ].join("\n"),
+  )
+}
+
+describe("workflow command via HTTP API", () => {
+  test("lists workflows via POST /session/:id/command", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await setupWorkflow(tmp.path)
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        const app = Server.Default().app
+
+        // Pass directory so InstanceMiddleware resolves the correct project root.
+        const res = await app.request(`/session/${session.id}/command`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "x-opencode-directory": tmp.path },
+          body: JSON.stringify({
+            command: "workflow",
+            arguments: "",
+            agent: "build",
+            model: "test/test-model",
+          }),
+        })
+
+        expect(res.status).toBe(200)
+        const body = await res.json()
+        const text = body.parts?.findLast((p: { type: string; text?: string }) => p.type === "text")?.text ?? ""
+        expect(text).toContain("Available workflows:")
+        expect(text).toContain("greet")
+
+        await svc.remove(session.id)
+      },
+    })
+  })
+
+  test("executes workflow via POST /session/:id/command", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await setupWorkflow(tmp.path)
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        const app = Server.Default().app
+
+        const res = await app.request(`/session/${session.id}/command`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "x-opencode-directory": tmp.path },
+          body: JSON.stringify({
+            command: "workflow",
+            arguments: "greet name=World",
+            agent: "build",
+            model: "test/test-model",
+          }),
+        })
+
+        expect(res.status).toBe(200)
+        const body = await res.json()
+        const text = body.parts?.findLast((p: { type: string; text?: string }) => p.type === "text")?.text ?? ""
+        expect(text).toContain("Workflow greet complete.")
+        expect(text).toContain("Hello, World!")
+        expect(text).toContain("greeting name=World")
+
+        await svc.remove(session.id)
+      },
+    })
+  })
+
+  test("returns error for unknown workflow", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await setupWorkflow(tmp.path)
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        const app = Server.Default().app
+
+        const res = await app.request(`/session/${session.id}/command`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "x-opencode-directory": tmp.path },
+          body: JSON.stringify({
+            command: "workflow",
+            arguments: "nonexistent",
+            agent: "build",
+            model: "test/test-model",
+          }),
+        })
+
+        expect(res.status).toBe(200)
+        const body = await res.json()
+        const text = body.parts?.findLast((p: { type: string; text?: string }) => p.type === "text")?.text ?? ""
+        expect(text).toContain("Workflow not found: nonexistent")
+
+        await svc.remove(session.id)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/workflow/bare-globals.test.ts
+++ b/packages/opencode/test/workflow/bare-globals.test.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "bun:test"
+import fs from "fs"
+import path from "path"
+import os from "os"
+
+// Inline the bare-globals logic to test independently of the Effect runtime
+function importBareGlobals(source: string) {
+  if (!source.includes("export const meta")) return undefined
+  const metaMatch = source.match(/export\s+const\s+meta\s*=\s*\{/)
+  if (!metaMatch || metaMatch.index === undefined) return undefined
+  const braceOpen = metaMatch.index + metaMatch[0].length - 1
+  let depth = 0
+  let metaEnd = -1
+  for (let i = braceOpen; i < source.length; i++) {
+    if (source[i] === "{") depth++
+    else if (source[i] === "}") { depth--; if (depth === 0) { metaEnd = i + 1; break } }
+  }
+  if (metaEnd === -1) return undefined
+  const metaSource = source.slice(braceOpen, metaEnd)
+  let meta: any
+  try { meta = new Function("return " + metaSource)() } catch { return undefined }
+  if (!meta?.name) return undefined
+  const body = (source.slice(0, metaMatch.index) + source.slice(metaEnd)).replace(/^export\s+/gm, "").trim()
+  const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as typeof Function
+  const fn = new AsyncFunction("args", "agent", "parallel", "phase", "log", body)
+  return { meta, fn }
+}
+
+test("parses and runs a bare-globals workflow", async () => {
+  const source = `
+export const meta = {
+  name: 'test-bare',
+  description: 'A test',
+  phases: [{ title: 'P1' }, { title: 'P2' }],
+}
+
+phase('P1')
+log('starting')
+const result = await agent('do something', { model: 'test/model' })
+phase('P2')
+const items = await parallel([
+  () => agent('task 1', { model: 'test/model' }),
+  () => agent('task 2', { model: 'test/model' }),
+])
+log('done')
+return { result, items }
+`
+  const parsed = importBareGlobals(source)
+  expect(parsed).not.toBeUndefined()
+  expect(parsed!.meta.name).toBe("test-bare")
+  expect(parsed!.meta.phases).toHaveLength(2)
+
+  const phases: string[] = []
+  const logs: string[] = []
+  const agentCalls: any[] = []
+  const mockAgent = async (prompt: string, opts?: any) => {
+    agentCalls.push({ prompt, opts })
+    return { answer: "mocked-" + agentCalls.length }
+  }
+  const mockParallel = async (tasks: any[]) => Promise.all(tasks.map((t: any) => t()))
+  const mockPhase = (name: string) => phases.push(name)
+  const mockLog = (msg: string) => logs.push(msg)
+
+  const result = await parsed!.fn({}, mockAgent, mockParallel, mockPhase, mockLog)
+  expect(phases).toEqual(["P1", "P2"])
+  expect(logs).toEqual(["starting", "done"])
+  expect(agentCalls).toHaveLength(3)
+  expect(result.result).toEqual({ answer: "mocked-1" })
+  expect(result.items).toHaveLength(2)
+})
+
+test("parses research-market.workflow.js", async () => {
+  const file = "/Users/engineer/workspace/backtest/.agents/workflows/research-market.workflow.js"
+  if (!fs.existsSync(file)) return // skip if not present
+  const source = fs.readFileSync(file, "utf8")
+  const parsed = importBareGlobals(source)
+  expect(parsed).not.toBeUndefined()
+  expect(parsed!.meta.name).toBe("research-market")
+  expect(parsed!.meta.phases!.length).toBeGreaterThan(0)
+
+  // Run with mocks to verify it completes all phases
+  const phases: string[] = []
+  const logs: string[] = []
+  let callCount = 0
+  const mockAgent = async () => {
+    callCount++
+    // Return shape varies by phase: intake returns plan, gather returns data, panel returns verdict, etc.
+    return { asset_class: "crypto", assets: ["BTC"], gather_skills: ["s1"], panel_skills: ["p1"], desk_skill: "d1", chair_skill: "c1", portfolio_provided: false, portfolio_summary: "", side: "long", findings: [], summary: "mock", seat: "s1", read: "mock read", verdict: "HOLD", confidence: "medium", answer: "hold", decision: "hold", tranche_plan: "none", agreement: [], disagreement: [], key_risks: [], invalidation: "n/a", buy_side: "n/a", sell_side: "n/a", verdict_tally: "1/1" }
+  }
+  const mockParallel = async (tasks: any[]) => {
+    const results = []
+    for (const t of tasks) { results.push(await t()) }
+    return results
+  }
+  const mockPhase = (name: string) => phases.push(name)
+  const mockLog = (msg: string) => logs.push(msg)
+
+  const result: any = await parsed!.fn({ question: "test?", date: "2026-06-17" }, mockAgent, mockParallel, mockPhase, mockLog)
+  expect(phases).toContain("Intake")
+  expect(phases).toContain("Gather")
+  expect(phases).toContain("Decide")
+  expect(result.asset_class).toBe("crypto")
+})
+
+test("returns undefined for standard workflow format", () => {
+  const source = `
+import { workflow } from "@opencode-ai/plugin"
+export default workflow({
+  name: "standard",
+  run(args, ctx) { return {} }
+})
+`
+  expect(importBareGlobals(source)).toBeUndefined()
+})

--- a/packages/opencode/test/workflow/workflow-command.test.ts
+++ b/packages/opencode/test/workflow/workflow-command.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Effect, Layer } from "effect"
+import { SessionPrompt } from "@/session/prompt"
+import { Session } from "@/session/session"
+import { disposeAllInstances, TestInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(Layer.mergeAll(SessionPrompt.defaultLayer, Session.defaultLayer))
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+describe("workflow command", () => {
+  it.instance("lists and runs project workflows", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const opencodeDir = path.join(test.directory, ".opencode")
+      const workflowDir = path.join(opencodeDir, "workflows")
+      const pluginLink = path.join(opencodeDir, "node_modules", "@opencode-ai", "plugin")
+      yield* Effect.promise(() => fs.mkdir(workflowDir, { recursive: true }))
+      yield* Effect.promise(() => fs.mkdir(path.dirname(pluginLink), { recursive: true }))
+      yield* Effect.promise(() => fs.symlink("/Users/engineer/workspace/opencode/packages/plugin", pluginLink, "dir"))
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(workflowDir, "hello.ts"),
+          [
+            'import { workflow } from "@opencode-ai/plugin"',
+            "",
+            "export default workflow({",
+            '  name: "hello",',
+            '  description: "test workflow",',
+            "  arguments: { topic: { type: 'string', description: 'topic' } },",
+            "  async run(args, ctx) {",
+            '    ctx.log(`topic=${String(args.topic ?? "")}`)',
+            "    return `done ${String(args.topic ?? '')}`",
+            "  },",
+            "})",
+            "",
+          ].join("\n"),
+        ),
+      )
+
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create()
+      const prompt = yield* SessionPrompt.Service
+
+      const listed = yield* prompt.command({
+        sessionID: session.id,
+        command: "workflow",
+        arguments: "",
+        agent: "build",
+        model: "test/test-model",
+      })
+      expect(listed.parts.findLast((part) => part.type === "text")?.text ?? "").toContain("Available workflows:")
+
+      const result = yield* prompt.command({
+        sessionID: session.id,
+        command: "workflow",
+        arguments: "hello topic=world",
+        agent: "build",
+        model: "test/test-model",
+      })
+      const text = result.parts.findLast((part) => part.type === "text")?.text ?? ""
+      expect(text).toContain("Workflow hello complete.")
+      expect(text).toContain("done world")
+      expect(text).toContain("topic=world")
+    }),
+  )
+})

--- a/packages/opencode/test/workflow/workflow-command.test.ts
+++ b/packages/opencode/test/workflow/workflow-command.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
+import { fileURLToPath } from "url"
 import { Effect, Layer } from "effect"
 import { SessionPrompt } from "@/session/prompt"
 import { Session } from "@/session/session"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
+
+// Resolve @opencode-ai/plugin from the workspace — uses the bun workspace symlink
+// so the path works on any machine without hardcoding.
+const PLUGIN_DIR = fileURLToPath(import.meta.resolve("@opencode-ai/plugin"))
 
 const it = testEffect(Layer.mergeAll(SessionPrompt.defaultLayer, Session.defaultLayer))
 
@@ -22,7 +27,7 @@ describe("workflow command", () => {
       const pluginLink = path.join(opencodeDir, "node_modules", "@opencode-ai", "plugin")
       yield* Effect.promise(() => fs.mkdir(workflowDir, { recursive: true }))
       yield* Effect.promise(() => fs.mkdir(path.dirname(pluginLink), { recursive: true }))
-      yield* Effect.promise(() => fs.symlink("/Users/engineer/workspace/opencode/packages/plugin", pluginLink, "dir"))
+      yield* Effect.promise(() => fs.symlink(PLUGIN_DIR, pluginLink, "dir"))
       yield* Effect.promise(() =>
         Bun.write(
           path.join(workflowDir, "hello.ts"),

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -11,6 +11,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./tool": "./src/tool.ts",
+    "./workflow": "./src/workflow.ts",
     "./tui": "./src/tui.ts"
   },
   "files": [

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -15,8 +15,10 @@ import type { Provider as ProviderV2, Model as ModelV2 } from "@opencode-ai/sdk/
 
 import type { BunShell } from "./shell.js"
 import { type ToolDefinition } from "./tool.js"
+import type { WorkflowDefinition } from "./workflow.js"
 
 export * from "./tool.js"
+export * from "./workflow.js"
 
 export type ProviderContext = {
   source: "env" | "config" | "custom" | "api"
@@ -225,6 +227,7 @@ export interface Hooks {
   tool?: {
     [key: string]: ToolDefinition
   }
+  workflow?: () => Promise<Record<string, WorkflowDefinition | string>>
   auth?: AuthHook
   provider?: ProviderHook
   /**

--- a/packages/plugin/src/workflow.ts
+++ b/packages/plugin/src/workflow.ts
@@ -1,0 +1,127 @@
+type WorkflowArgumentType = "string" | "number" | "boolean"
+
+type WorkflowArgument = {
+  type?: WorkflowArgumentType
+  default?: unknown
+  description?: string
+}
+
+type WorkflowArguments = Record<string, WorkflowArgument>
+
+type WorkflowArgumentValue<T extends WorkflowArgument> = T["type"] extends "number"
+  ? number
+  : T["type"] extends "boolean"
+    ? boolean
+    : string
+
+type WorkflowArgs<Args extends WorkflowArguments | undefined> = Args extends WorkflowArguments
+  ? { readonly [Key in keyof Args]?: WorkflowArgumentValue<Args[Key]> }
+  : Record<string, unknown>
+
+export type WorkflowAgentInput = {
+  prompt: string
+  agent?: string
+  model?: string
+  variant?: string
+  files?: string[]
+  schema?: Record<string, unknown>
+  onError?: "fail" | "null"
+}
+
+export type WorkflowAgentResult = {
+  data: unknown
+  text: string
+}
+
+export type WorkflowParallelOptions = { concurrencyLimit?: number }
+export type WorkflowPipelineOptions = { concurrencyLimit?: number }
+
+export interface WorkflowToolFn {
+  (name: string, args?: Record<string, unknown>, options?: { timeout?: number; onError: "null" }): Promise<{
+    output: string
+    metadata?: Record<string, unknown>
+  } | null>
+  (
+    name: string,
+    args?: Record<string, unknown>,
+    options?: { timeout?: number; onError?: "fail" | "null" },
+  ): Promise<{
+    output: string
+    metadata?: Record<string, unknown>
+  }>
+}
+
+export interface WorkflowPipelineFn {
+  <I, A>(
+    items: readonly I[],
+    s1: (prev: I, item: I, index: number) => Promise<A>,
+    options?: WorkflowPipelineOptions,
+  ): Promise<(A | null)[]>
+  <I, A, B>(
+    items: readonly I[],
+    s1: (prev: I, item: I, index: number) => Promise<A>,
+    s2: (prev: A, item: I, index: number) => Promise<B>,
+    options?: WorkflowPipelineOptions,
+  ): Promise<(B | null)[]>
+  <I, A, B, C>(
+    items: readonly I[],
+    s1: (prev: I, item: I, index: number) => Promise<A>,
+    s2: (prev: A, item: I, index: number) => Promise<B>,
+    s3: (prev: B, item: I, index: number) => Promise<C>,
+    options?: WorkflowPipelineOptions,
+  ): Promise<(C | null)[]>
+}
+
+export type WorkflowContext = {
+  readonly budgetRemaining: number
+  readonly budget: {
+    readonly total: null
+    spent(): number
+    remaining(): number
+    readonly tokensTotal: null
+    tokensSpent(): number
+    tokensRemaining(): number
+  }
+  setPhase(phase: string): void
+  log(message: string): void
+  parallel<T>(tasks: readonly (() => Promise<T>)[], options?: WorkflowParallelOptions): Promise<(T | null)[]>
+  pipeline: WorkflowPipelineFn
+  agent(input: WorkflowAgentInput): Promise<WorkflowAgentResult | null>
+  tool: WorkflowToolFn
+  shell(command: string, opts?: { timeout?: number; cwd?: string }): Promise<{ output: string; exitCode: number }>
+  workflow(name: string, args?: Record<string, unknown>): Promise<unknown>
+  question(input: { question: string; options?: readonly string[]; timeout?: number }): Promise<{ answer: string }>
+}
+
+export type WorkflowPhase = string | { title: string; detail?: string; model?: string }
+
+export type WorkflowDefinition<Args extends WorkflowArguments | undefined = WorkflowArguments | undefined> = {
+  meta: {
+    name: string
+    description?: string
+    whenToUse?: string
+    phases?: readonly WorkflowPhase[]
+    arguments?: Args
+  }
+  run(args: WorkflowArgs<Args>, ctx: WorkflowContext): Promise<unknown>
+}
+
+export function workflow<const Args extends WorkflowArguments | undefined = undefined>(input: {
+  name: string
+  description?: string
+  whenToUse?: string
+  phases?: readonly WorkflowPhase[]
+  arguments?: Args
+  run(args: WorkflowArgs<Args>, ctx: WorkflowContext): Promise<unknown>
+}): WorkflowDefinition<Args> {
+  return {
+    meta: {
+      name: input.name,
+      description: input.description,
+      whenToUse: input.whenToUse,
+      phases: input.phases,
+      arguments: input.arguments,
+    },
+    run: input.run,
+  }
+}


### PR DESCRIPTION
## Bare-globals workflow shim for Claude Code dynamic workflows

Adds support for running Claude Code `.agents/workflows/` files (bare-globals format) through the opencode workflow engine.

### What works
- **Bare-globals parsing**: `agent()`, `parallel()`, `phase()`, `log()`, `args` as top-level globals
- **Discovery**: scans `.agents/workflows/` and `.opencode/workflows/` directories
- **Simple text completions**: `agent('What is 2+2?')` → '4'
- **Structured output (JSON schemas)**: `agent(prompt, {schema})` → parsed JSON object
- **Multi-phase workflows**: `phase()` + sequential agent calls
- **System prompt isolation**: workflow agent calls use minimal system prompt, bypassing AGENTS.md/skills
- **Copilot SDK fix**: tolerate multiple reasoning_opaque blocks from thinking models

### Known limitations
- **Tool access**: disabled by default for clean text completions. Workflows needing file access (like research-market) should pass `{ tools: true }` in agent options
- **Model override**: explicit model params don't work reliably with GitHub Copilot routing; uses default model
- **research-market**: completes without crash but produces thin output (needs tool access to read skill files)

### Files changed
- `packages/opencode/src/workflow/index.ts` — agent() rewrite with model resolution, system prompt, tool control, schema handling
- `packages/opencode/src/session/prompt.ts` — system override + wildcard tool disable
- `packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts` — tolerate multiple reasoning_opaque

### Tests
- 4/4 unit tests pass (bare-globals shim + workflow command)
- E2E verified: simple text, schema output, complex schema all produce correct results
