### PR TITLE
fix: postinstall.mjs now derives npm scope from package name (#234)

### DIFF
--- a/.tasks/234/STATE.md
+++ b/.tasks/234/STATE.md
@@ -1,0 +1,4 @@
+# Task 234 — STATE
+- phase: 6-pr-created
+- issue: #234
+- started: 2026-06-21T08:30:00Z

--- a/.tasks/234/design.md
+++ b/.tasks/234/design.md
@@ -1,0 +1,51 @@
+## Problem
+
+`packages/opencode/script/postinstall.mjs` hardcodes the platform binary package name as `opencode-${platform}-${arch}` (unscoped). When the opencode package is published under an npm scope (e.g. `@vibetechnologies/opencode`), the platform-specific optional deps also get scoped names. The postinstall fails because `require.resolve("opencode-linux-x64/package.json")` can't find `@vibetechnologies/opencode-linux-x64`.
+
+## Goal
+
+The postinstall script correctly resolves the platform-specific binary package regardless of whether the main package is scoped or unscoped.
+
+## Success Metric
+
+- `node postinstall.mjs` succeeds when run inside a package whose `name` is `opencode-ai` (unscoped) OR `@vibetechnologies/opencode` (scoped)
+- Existing install path for `opencode-ai` remains unbroken
+
+## Out of Scope
+
+- The `@vibetechnologies/opencode` fork's publish pipeline itself — only the postinstall script that ships with every fork.
+
+## Current State
+
+`packages/opencode/script/postinstall.mjs:50-69` — `findBinary()` constructs:
+```js
+const packageName = `opencode-${platform}-${arch}`
+```
+This is correct for `opencode-ai` (unscoped) but wrong for scoped forks.
+
+## Proposed Design
+
+Read the package's own `package.json` `name` field, extract the npm scope (everything before the last `/`), and prepend it:
+
+```js
+const selfPkg = JSON.parse(fs.readFileSync(path.join(__dirname, "package.json"), "utf8"))
+const scope = selfPkg.name.replace(/[^/]+$/, "")
+const packageName = `${scope}opencode-${platform}-${arch}`
+```
+
+- `"opencode-ai"` → scope `""` → `packageName` = `"opencode-linux-x64"` ✅
+- `"@vibetechnologies/opencode"` → scope `"@vibetechnologies/"` → `packageName` = `"@vibetechnologies/opencode-linux-x64"` ✅
+
+## Alternatives Considered
+
+1. **Match by suffix from optionalDependencies** — more robust against naming variations, but fragile if multiple variants match (e.g. `opencode-linux-x64` and `opencode-linux-x64-musl` both end with same suffix).
+2. **Hardcode scope as build parameter** — requires build system changes; breaks the auto-derivation property.
+3. **Pass scope via env var** — fragile, easy to forget.
+
+## Risks & Open Questions
+
+- None identified. The change is backward compatible: for unscoped names `replace(/[^/]+$/, "")` yields empty string, producing the same result as before.
+
+## Touched Surface
+
+- `packages/opencode/script/postinstall.mjs`

--- a/.tasks/234/plan.md
+++ b/.tasks/234/plan.md
@@ -1,0 +1,24 @@
+## Approach Summary
+
+Fix already implemented. Remaining work: verify fix correctness, review, create PR, CI, merge.
+
+## Tradeoff: Speed vs Quality
+- chosen: fast
+- rationale: single-file change, purely additive logic. No behavioral change for unscoped packages.
+
+## Tasks
+| # | Title | Files | Depends on | Parallel group | Suggested model |
+|---|-------|-------|------------|----------------|-----------------|
+| 1 | Verify fix | postinstall.mjs | — | A | deepseek |
+| 2 | Code review | postinstall.mjs | — | A | deepseek |
+| 3 | Create PR + CI | — | 1, 2 | B | deepseek |
+| 4 | Post-merge prod verify | — | 3 | B | deepseek |
+
+## Done Criteria
+1. `node postinstall.mjs` succeeds for both scoped and unscoped package names in a mock package
+2. Review finds no issues
+3. PR merged to `dev`
+4. CI green
+
+## Rollback Plan
+`git revert` on the merge commit.

--- a/.tasks/234/review.md
+++ b/.tasks/234/review.md
@@ -1,0 +1,14 @@
+## Review: postinstall.mjs scoped package fix (#234)
+
+### Files checked
+- `packages/opencode/script/postinstall.mjs`
+
+### Findings
+- `packages/opencode/script/postinstall.mjs:52` — was `const packageName = \`opencode-${platform}-${arch}\``
+- Now reads own `package.json`, extracts scope, prepends it to package name
+- Logic: `selfPkg.name.replace(/[^/]+$/, "")` correctly handles both scoped and unscoped names
+- No security issues: only reads local `package.json`, no new shell calls or network access
+- Backward compatible: for `"opencode-ai"` (unscoped), regex yields `""`, producing same result as before
+- Error message now shows correct scoped name (e.g. `@vibetechnologies/opencode-linux-x64`)
+
+**VERDICT: pass**

--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -49,11 +49,14 @@ function detectPlatformAndArch() {
 
 function findBinary() {
   const { platform, arch } = detectPlatformAndArch()
-  const packageName = `opencode-${platform}-${arch}`
   const binaryName = platform === "windows" ? "opencode.exe" : "opencode"
+  let packageName
 
   try {
-    // Use require.resolve to find the package
+    const selfPkg = JSON.parse(fs.readFileSync(path.join(__dirname, "package.json"), "utf8"))
+    const scope = selfPkg.name.replace(/[^/]+$/, "")
+    packageName = `${scope}opencode-${platform}-${arch}`
+
     const packageJsonPath = require.resolve(`${packageName}/package.json`)
     const packageDir = path.dirname(packageJsonPath)
     const binaryPath = path.join(packageDir, "bin", binaryName)
@@ -64,7 +67,7 @@ function findBinary() {
 
     return { binaryPath, binaryName }
   } catch (error) {
-    throw new Error(`Could not find package ${packageName}: ${error.message}`, { cause: error })
+    throw new Error(`Could not find package ${packageName || "unknown"}: ${error.message}`, { cause: error })
   }
 }
 


### PR DESCRIPTION
## Summary

- `postinstall.mjs` hardcoded platform binary package as `opencode-${platform}-${arch}` (unscoped)
- When published under an npm scope (e.g. `@vibetechnologies/opencode`), the platform packages get scoped names too
- Fix: read own `package.json`, extract scope, prepend it when resolving the platform package
- Works for both unscoped (`opencode-ai`) and scoped (`@vibetechnologies/opencode`) names

## Test plan

- [x] Verified with mock packages for both scoped and unscoped names: `node postinstall.mjs` exits 0 in both cases
- [x] Error message for missing platform package now shows correct scoped name

## Closes

Closes #234

## Notes

- design: `.tasks/234/design.md`
- plan:   `.tasks/234/plan.md`
- review: `.tasks/234/review.md`
