### PR TITLE
feat(file): add GET /file/roots to enumerate filesystem roots

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/file.ts
@@ -92,6 +92,11 @@ export const LegacyStatus = Schema.Struct({
   status: Schema.Literals(["added", "deleted", "modified"]),
 }).annotate({ identifier: "File" })
 
+export const Root = Schema.Struct({
+  path: Schema.String,
+  label: Schema.String,
+}).annotate({ identifier: "FileRoot" })
+
 export const FilePaths = {
   findText: "/find",
   findFile: "/find/file",
@@ -99,6 +104,7 @@ export const FilePaths = {
   list: "/file",
   content: "/file/content",
   status: "/file/status",
+  roots: "/file/roots",
 } as const
 
 export const FileApi = HttpApi.make("file")
@@ -163,6 +169,16 @@ export const FileApi = HttpApi.make("file")
             identifier: "file.status",
             summary: "Get file status",
             description: "Get the git status of all files in the project.",
+          }),
+        ),
+        HttpApiEndpoint.get("roots", FilePaths.roots, {
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Array(Root), "Filesystem roots"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "file.roots",
+            summary: "List filesystem roots",
+            description: "List the machine's mounted drives, filesystem roots, and home directory for browsing.",
           }),
         ),
       )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
@@ -7,6 +7,7 @@ import { Location } from "@opencode-ai/core/location"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { Effect, Layer, Option } from "effect"
 import ignore from "ignore"
+import os from "os"
 import path from "path"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
@@ -128,6 +129,45 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
       return []
     })
 
+    const roots = Effect.fn("FileHttpApi.roots")(function* () {
+      const raw = yield* FSUtil.Service
+      const home = os.homedir()
+      if (process.platform === "win32") {
+        const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")
+        const drives = yield* Effect.all(
+          letters.map((letter) =>
+            raw
+              .existsSafe(`${letter}:\\`)
+              .pipe(Effect.map((exists) => (exists ? { path: `${letter}:\\`, label: `${letter}:` } : undefined))),
+          ),
+        )
+        return [
+          ...drives.filter((drive): drive is { path: string; label: string } => drive !== undefined),
+          { path: home, label: "Home" },
+        ]
+      }
+      const mountBases = ["/mnt", "/media", "/Volumes"]
+      const mounts = yield* Effect.all(
+        mountBases.map((base) =>
+          raw.existsSafe(base).pipe(
+            Effect.flatMap((exists) =>
+              exists
+                ? raw.readDirectoryEntries(base).pipe(
+                    Effect.map((entries) =>
+                      entries
+                        .filter((entry) => entry.type === "directory")
+                        .map((entry) => ({ path: path.join(base, entry.name), label: entry.name })),
+                    ),
+                    Effect.catch(() => Effect.succeed([] as { path: string; label: string }[])),
+                  )
+                : Effect.succeed([] as { path: string; label: string }[]),
+            ),
+          ),
+        ),
+      )
+      return [{ path: "/", label: "/" }, { path: home, label: "Home" }, ...mounts.flat()]
+    })
+
     return handlers
       .handle("findText", findText)
       .handle("findFile", findFile)
@@ -135,5 +175,6 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
       .handle("list", list)
       .handle("content", content)
       .handle("status", status)
+      .handle("roots", roots)
   }),
 ).pipe(Layer.provide(LocationServiceMap.layer))

--- a/packages/opencode/test/server/httpapi-file.test.ts
+++ b/packages/opencode/test/server/httpapi-file.test.ts
@@ -70,4 +70,21 @@ describe("file HttpApi", () => {
     expect(symbols.status).toBe(200)
     expect(await symbols.json()).toEqual([])
   })
+
+  test("serves roots endpoint", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const roots = await request(FilePaths.roots, tmp.path)
+
+    expect(roots.status).toBe(200)
+    const body = await roots.json()
+    expect(Array.isArray(body)).toBe(true)
+    for (const root of body) {
+      expect(typeof root.path).toBe("string")
+      expect(typeof root.label).toBe("string")
+    }
+    if (process.platform !== "win32") {
+      expect(body).toContainEqual(expect.objectContaining({ path: "/" }))
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- Adds a new read-only `GET /file/roots` endpoint to the experimental file HttpApi group (alongside `/file`, `/file/content`, `/file/status`).
- Returns `[{ path, label }]`: on POSIX, `/`, `$HOME`, and any subdirectories under `/mnt`, `/media`, `/Volumes` that exist; on Windows, existing drive letters `A:`–`Z:` plus the home directory.
- No traversal params — enumeration only, same auth/workspace-routing middleware stack as the rest of the `file` group.

## Why
opencode-mobile issue [dzianisv/opencode-mobile#57](https://github.com/dzianisv/opencode-mobile/issues/57): the directory browser can only descend from a manually-typed path because there was no way to discover the server's filesystem roots (multiple drives on Windows, mount points, home dir). This endpoint gives clients a starting point to pin as top-level entries.

## Endpoint shape
```
GET /file/roots
200 -> [{ "path": "/", "label": "/" }, { "path": "/home/user", "label": "Home" }, ...]
```

## Test plan
- [x] `bun typecheck` clean in `packages/opencode`
- [x] `bun test test/server/httpapi-file.test.ts` — added a `serves roots endpoint` case, all 3 tests pass
- [x] Manual reasoning: POSIX path returns `/` + home + mount subdirs; Windows path checks each drive letter via `existsSafe`

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>