### PR TITLE
fix(server): wire the real SessionExecution local layer, not the noop stub

### DIFF
--- a/packages/server/src/handlers.ts
+++ b/packages/server/src/handlers.ts
@@ -2,6 +2,11 @@ import { SessionV2 } from "@opencode-ai/core/session"
 import { LocationServiceMap } from "@opencode-ai/core/location-layer"
 import { PermissionSaved } from "@opencode-ai/core/permission/saved"
 import { PtyTicket } from "@opencode-ai/core/pty/ticket"
+import { SessionStore } from "@opencode-ai/core/session/store"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { EventV2 } from "@opencode-ai/core/event"
+import { Database } from "@opencode-ai/core/database/database"
+import { ProjectV2 } from "@opencode-ai/core/project"
 import { Layer } from "effect"
 import { layer as locationLayer } from "./groups/location"
 import { sessionLocationLayer } from "./middleware/session-location"
@@ -48,8 +53,32 @@ export const handlers = Layer.mergeAll(
 ).pipe(
   Layer.provide(sessionLocationLayer),
   Layer.provide(locationLayer),
-  Layer.provide(SessionV2.defaultLayer),
-  Layer.provide(SessionExecutionLocal.defaultLayer),
+  // NOTE: intentionally NOT `SessionV2.defaultLayer`. That export bakes
+  // `SessionExecution.noopLayer` into its own dependency graph (see
+  // packages/core/src/session.ts), which permanently resolves the
+  // session's SessionExecution.Service requirement to a no-op before this
+  // layer is ever built. Providing `SessionExecutionLocal.defaultLayer`
+  // from out here (as this file used to, right below) cannot reach past
+  // that already-closed-over dependency: Effect's Layer.provide binds a
+  // layer's requirement at the point the layer itself is constructed, not
+  // at the point it's later merged in. The practical symptom was that
+  // POST /session/{id}/prompt admitted durably (200, admittedSeq set) but
+  // session.wake()/resume() were silently no-ops, so the agent loop never
+  // ran (cost/tokens stayed 0, no assistant message was ever produced).
+  // Compose the session layer here instead, swapping in the real local
+  // executor, mirroring the (correct) pattern already used by
+  // packages/core/src/public/opencode.ts's `SessionsLayer`.
+  Layer.provide(
+    SessionV2.layer.pipe(
+      Layer.provide(SessionExecutionLocal.defaultLayer),
+      Layer.provide(SessionStore.defaultLayer),
+      Layer.provide(SessionProjector.defaultLayer),
+      Layer.provide(EventV2.defaultLayer),
+      Layer.provide(Database.defaultLayer),
+      Layer.provide(ProjectV2.defaultLayer),
+      Layer.orDie,
+    ),
+  ),
   Layer.provide(PermissionSaved.defaultLayer),
   Layer.provide(PtyTicket.defaultLayer),
   Layer.provide(LocationServiceMap.layer),


### PR DESCRIPTION
## Summary
- Fixes the headless `opencode serve` HTTP API silently never executing admitted prompts: `POST /session/{id}/prompt` returns 200 with an `admittedSeq`, but the agent loop never runs (cost/tokens stay 0, no assistant message is ever produced).
- Root cause: `packages/server/src/handlers.ts` provided `SessionV2.defaultLayer`, which bakes `SessionExecution.noopLayer` into its own internal `Layer.provide` chain (`packages/core/src/session.ts`). That permanently closes the session's `SessionExecution.Service` dependency over the noop at the point `defaultLayer` is built. The sibling `Layer.provide(SessionExecutionLocal.defaultLayer)` right below it in `handlers.ts` can never reach past that already-resolved dependency — Effect's `Layer.provide` binds a requirement when the layer itself is constructed, not when it's later merged into a different layer graph.
- Fix: build the session layer here from the raw `SessionV2.layer` plus its concrete sub-layers, substituting `SessionExecutionLocal.defaultLayer` for the noop — mirroring the already-correct pattern in `packages/core/src/public/opencode.ts`'s `SessionsLayer`, which never had this bug for the same reason (it wires `SessionV2.layer`, not `defaultLayer`).
- Confirmed present in every published version I checked (1.17.9 through the current `latest`, 1.17.17, and `dev` HEAD) — not something an `npm i @vibetechnologies/opencode@latest` + restart fixes.
- `POST /session/{id}/wait` still 503s ("Session wait is not available yet") — that's a separate, genuinely-unimplemented V2 API stub (`packages/core/src/session.ts`'s `wait:` handler unconditionally throws `OperationUnavailableError`), not the thing blocking execution. Clients should poll `GET /session/{id}/message` instead until that's implemented.

## Test plan
- [ ] CI typecheck/build (github-hosted runners — could not run `bun install` locally, both machines I tested from were disk-constrained under 2GB free)
- [ ] After merge + release: `npm i -g @vibetechnologies/opencode@latest && systemctl --user restart opencode-serve.service` on a server host, then create a session, `POST /session/{id}/prompt`, and poll `GET /session/{id}/message` until a real assistant message appears (previously stuck at `cost=0`, empty messages, forever)

🤖 Generated with [Claude Code](https://claude.com/claude-code)